### PR TITLE
Add Linux-specific shadow margin for transparent widgets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p3#d72e8bfe99170a2487883c66adeb193055412e61"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p5#7038636d7fde63b6fda4d025fe73945adf58dc2d"
 dependencies = [
  "iced_core",
  "iced_debug",
@@ -1500,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p3#d72e8bfe99170a2487883c66adeb193055412e61"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p5#7038636d7fde63b6fda4d025fe73945adf58dc2d"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
@@ -1517,7 +1517,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p3#d72e8bfe99170a2487883c66adeb193055412e61"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p5#7038636d7fde63b6fda4d025fe73945adf58dc2d"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1527,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p3#d72e8bfe99170a2487883c66adeb193055412e61"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p5#7038636d7fde63b6fda4d025fe73945adf58dc2d"
 dependencies = [
  "futures",
  "iced_core",
@@ -1541,7 +1541,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p3#d72e8bfe99170a2487883c66adeb193055412e61"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p5#7038636d7fde63b6fda4d025fe73945adf58dc2d"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p3#d72e8bfe99170a2487883c66adeb193055412e61"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p5#7038636d7fde63b6fda4d025fe73945adf58dc2d"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p3#d72e8bfe99170a2487883c66adeb193055412e61"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p5#7038636d7fde63b6fda4d025fe73945adf58dc2d"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p3#d72e8bfe99170a2487883c66adeb193055412e61"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p5#7038636d7fde63b6fda4d025fe73945adf58dc2d"
 dependencies = [
  "bytes",
  "iced_core",
@@ -1592,7 +1592,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p3#d72e8bfe99170a2487883c66adeb193055412e61"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p5#7038636d7fde63b6fda4d025fe73945adf58dc2d"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p3#d72e8bfe99170a2487883c66adeb193055412e61"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p5#7038636d7fde63b6fda4d025fe73945adf58dc2d"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
@@ -1627,7 +1627,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p3#d72e8bfe99170a2487883c66adeb193055412e61"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p5#7038636d7fde63b6fda4d025fe73945adf58dc2d"
 dependencies = [
  "iced_renderer",
  "log",
@@ -1640,7 +1640,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p3#d72e8bfe99170a2487883c66adeb193055412e61"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p5#7038636d7fde63b6fda4d025fe73945adf58dc2d"
 dependencies = [
  "iced_debug",
  "iced_program",
@@ -1658,6 +1658,7 @@ dependencies = [
  "window_clipboard",
  "windows 0.58.0",
  "winit",
+ "x11rb",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,9 +479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -500,6 +520,15 @@ checksum = "bd63e33452ffdafd39924c4f05a5dd1e94db646c779c6bd59148a3d95fff5ad4"
 dependencies = [
  "thiserror 2.0.17",
  "x11rb",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -799,13 +828,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
+name = "dunce"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "endi"
@@ -1008,6 +1034,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1321,6 +1353,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,23 +1451,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.4",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -1451,11 +1472,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1765,12 +1784,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -2038,12 +2057,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,23 +2116,6 @@ dependencies = [
  "spirv",
  "thiserror 2.0.17",
  "unicode-ident",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -2616,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
@@ -2887,6 +2883,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3026,13 +3023,12 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
-version = "0.12.25"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6eff9328d40131d43bd911d42d79eb6a47312002a4daefc9e37f17e74a7701a"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
  "h2",
  "http",
@@ -3040,23 +3036,19 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -3065,7 +3057,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -3132,12 +3123,24 @@ version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -3151,11 +3154,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3166,12 +3197,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -3290,15 +3315,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -3314,23 +3339,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.3"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -3471,14 +3484,12 @@ dependencies = [
  "directories",
  "iced",
  "keyring",
- "objc2-quartz-core 0.3.2",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
  "toml",
- "url",
 ]
 
 [[package]]
@@ -3609,27 +3620,6 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
 dependencies = [
- "libc",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
  "libc",
 ]
 
@@ -3769,29 +3759,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
- "tokio-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -3806,9 +3774,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -3835,17 +3803,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -3858,31 +3826,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.23.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.3",
  "toml_parser",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.4"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -3978,9 +3955,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -3992,7 +3969,6 @@ dependencies = [
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.17",
- "utf-8",
 ]
 
 [[package]]
@@ -4065,12 +4041,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -4360,6 +4330,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4705,17 +4684,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5054,6 +5022,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5185,7 +5159,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow",
+ "winnow 0.7.14",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -5214,7 +5188,7 @@ checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
- "winnow",
+ "winnow 0.7.14",
  "zvariant",
 ]
 
@@ -5319,6 +5293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
 name = "zvariant"
 version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5327,7 +5307,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow",
+ "winnow 0.7.14",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -5355,5 +5335,5 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "winnow",
+ "winnow 0.7.14",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ keyring = { version = "3.6.3", features = [
   "sync-secret-service",
   "vendored",
 ] }
-reqwest = { version = "0.12.25", features = [
+reqwest = { version = "0.13.2", features = [
   "json",
   "rustls-tls",
   "native-tls-vendored",
@@ -52,30 +52,23 @@ tokio = { version = "1.48.0", features = [
   "time",
   "fs",
 ] }
-tokio-tungstenite = { version = "0.28.0", features = [
+tokio-tungstenite = { version = "0.29.0", features = [
   "rustls-tls-webpki-roots",
 ] }
-toml = "0.9.8"
+toml = "1.1.2+spec-1.1.0"
 url = "2.5.7"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-quartz-core = "0.3.2"
 
 [patch.crates-io]
-iced = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p3" }
-iced_winit = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p3" }
-iced_runtime = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p3" }
-iced_program = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p3" }
-iced_renderer = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p3" }
-iced_widget = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p3" }
-iced_core = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p3" }
-
-# iced_winit = { path = "vendor/iced/winit" }
-# iced_runtime = { path = "vendor/iced/runtime" }
-# iced_program = { path = "vendor/iced/program" }
-# iced_renderer = { path = "vendor/iced/renderer" }
-# iced_widget = { path = "vendor/iced/widget" }
-# iced_core = { path = "vendor/iced/core" }
+iced = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p5" }
+iced_winit = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p5" }
+iced_runtime = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p5" }
+iced_program = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p5" }
+iced_renderer = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p5" }
+iced_widget = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p5" }
+iced_core = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p5" }
 
 [profile.release]
 opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "snapdash"
 version = "0.0.1"
 edition = "2024"
-authors = ["Lukáš Svoboda <opensource@schizza.cz"]
+authors = ["Lukáš Svoboda <opensource@schizza.cz>"]
 license = "Apache-2.0"
 description = "A pluggable desktop widget system - Home Assistant today, anything tomorrow."
 repository = "https://github.com/schizza/snapdash"
@@ -10,17 +10,19 @@ homepage = "https://snapdash.schizza.cz"
 documentation = "https://github.com/schizza/snapdash#readme"
 readme = "README.md"
 keywords = ["widget", "dashboard", "home-assistant", "desktop", "gui"]
-categories = ["gui", "visualisation", "rendering"]
+categories = ["gui", "visualization", "rendering"]
 rust-version = "1.94"
 
 exclude = [
   "/.github/",
   "/.vscode/",
   "/.zed/",
+  "/.claude/",
   "/dist/",
   "/assets/screenshots/",
   "*.png",
   "*.gif",
+  ".DS_Store",
   "mac_build.sh",
 ]
 
@@ -30,36 +32,31 @@ diagnostics = []
 
 [dependencies]
 anyhow = "1.0.100"
-chrono = "0.4.42"
+chrono = { version = "0.4.42", default-features = false, features = ["clock"] }
 iced = { version = "0.14.0", features = ["wgpu", "tokio"] }
 directories = "6.0.0"
-keyring = { version = "3.6.3", features = [
-  "apple-native",
-  "windows-native",
-  "sync-secret-service",
-  "vendored",
-] }
-reqwest = { version = "0.13.2", features = [
+
+reqwest = { version = "0.13.2", default-features = false, features = [
   "json",
-  "rustls-tls",
-  "native-tls-vendored",
+  "rustls",
+  "http2",
 ] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
-tokio = { version = "1.48.0", features = [
-  "rt-multi-thread",
-  "macros",
-  "time",
-  "fs",
-] }
+serde_json = "1.0.149"
+tokio = { version = "1.48.0", features = ["rt-multi-thread", "time", "fs"] }
 tokio-tungstenite = { version = "0.29.0", features = [
   "rustls-tls-webpki-roots",
 ] }
-toml = "1.1.2+spec-1.1.0"
-url = "2.5.7"
+toml = "1.1.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-quartz-core = "0.3.2"
+keyring = { version = "3.6.3", features = ["apple-native"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+keyring = { version = "3.6.3", features = ["windows-native"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+keyring = { version = "3.6.3", features = ["sync-secret-service", "vendored"] }
 
 [patch.crates-io]
 iced = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p5" }
@@ -77,3 +74,9 @@ codegen-units = 1
 panic = "abort"
 strip = "symbols"
 debug = 0
+
+[profile.dev.package."*"]
+opt-level = 3
+
+[profile.dev]
+opt-level = 0

--- a/src/app.rs
+++ b/src/app.rs
@@ -795,4 +795,21 @@ impl Snapdash {
             WindowKind::Settings => inner,
         }
     }
+
+    /// Surface clear color for every window.
+    ///
+    /// All Snapdash windows are created with `window::Settings { transparent: true,
+    /// decorations: false, .. }` and draw their own rounded `card(...)` on top.
+    /// Without overriding the default `Program::style`, iced clears the surface to
+    /// the current `iced::Theme`'s opaque background, which then shows through at
+    /// the four corners as solid triangles (the area outside the rounded SDF but
+    /// inside the window rectangle). Clearing to `Color::TRANSPARENT` lets the
+    /// compositor blend those corner pixels with whatever is behind the window —
+    /// which is what every GTK4/libadwaita app does.
+    pub fn style(&self, _theme: &iced::Theme) -> iced::theme::Style {
+        iced::theme::Style {
+            background_color: iced::Color::TRANSPARENT,
+            text_color: self.theme.palette().text_primary,
+        }
+    }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -644,8 +644,12 @@ impl Snapdash {
 
                 self.pending_opens.push_back(WindowKind::Settings);
 
+                // The platform helper adds a transparent shadow margin on
+                // Linux (where we render our own shader shadow) and is a
+                // no-op on macOS/Windows (where the OS clips + draws its
+                // own shadow). See `ui::platform` module doc.
                 let settings = window::Settings {
-                    size: iced::Size::new(820.0, 950.0),
+                    size: crate::ui::platform::window_size(820.0, 950.0),
                     resizable: false,
                     decorations: false,
                     transparent: true,
@@ -668,8 +672,10 @@ impl Snapdash {
                     vec![entity_id]
                 };
 
+                // Platform helper: adds shadow margin on Linux, pass-through
+                // on macOS/Windows. See `ui::platform` module doc.
                 let win_settings = window::Settings {
-                    size: iced::Size::new(240.0, 160.0),
+                    size: crate::ui::platform::window_size(240.0, 160.0),
                     resizable: false,
                     decorations: false,
                     transparent: true,
@@ -787,25 +793,32 @@ impl Snapdash {
         let inner = crate::ui::chrome::window_content(self, win, id);
         let inner = crate::ui::chrome::with_debug_overlay(self, inner, win);
 
-        match win.kind {
+        let inner = match win.kind {
             WindowKind::Entity { .. } => {
                 let with_gear = crate::ui::chrome::with_gear_overlay(self, inner, win);
                 crate::ui::chrome::with_mouse_area(with_gear, id, win)
             }
             WindowKind::Settings => inner,
-        }
+        };
+
+        // Platform-specific outer wrapping:
+        // - Linux: transparent `SHADOW_MARGIN` padding around the card so
+        //   the iced-wgpu shader shadow has room to fade inside the surface.
+        // - macOS/Windows: pass-through. The OS hack in iced_winit clips the
+        //   window to a rounded shape and the OS draws the drop shadow.
+        crate::ui::platform::wrap_outer(inner)
     }
 
-    /// Surface clear color for every window.
+    /// Surface clear color. **Linux-only**: set to `Color::TRANSPARENT` so the
+    /// cleared pixels in the shadow margin actually composite as transparent
+    /// (the default theme background would show as an opaque color there).
     ///
-    /// All Snapdash windows are created with `window::Settings { transparent: true,
-    /// decorations: false, .. }` and draw their own rounded `card(...)` on top.
-    /// Without overriding the default `Program::style`, iced clears the surface to
-    /// the current `iced::Theme`'s opaque background, which then shows through at
-    /// the four corners as solid triangles (the area outside the rounded SDF but
-    /// inside the window rectangle). Clearing to `Color::TRANSPARENT` lets the
-    /// compositor blend those corner pixels with whatever is behind the window —
-    /// which is what every GTK4/libadwaita app does.
+    /// On macOS/Windows we intentionally do NOT install this callback (see
+    /// `main.rs`) — the OS hack clips the window to a rounded shape before
+    /// any cleared pixel is visible, so the default opaque theme background
+    /// is never seen and matches the pre-shadow-margin behavior users
+    /// reported looked "nice and optimal".
+    #[cfg(target_os = "linux")]
     pub fn style(&self, _theme: &iced::Theme) -> iced::theme::Style {
         iced::theme::Style {
             background_color: iced::Color::TRANSPARENT,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ fn main() -> iced::Result {
         app::Snapdash::update,
         app::Snapdash::view,
     )
+    .style(app::Snapdash::style)
     .subscription(app::Snapdash::subscription)
     .run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,21 @@ mod ui;
 use iced::daemon;
 
 fn main() -> iced::Result {
-    daemon(
+    // On Linux we install a custom `.style()` that clears the surface to
+    // `Color::TRANSPARENT` so the shadow-margin area around the card stays
+    // transparent (see `Snapdash::style` and `ui::platform`). On macOS and
+    // Windows the OS-level rounded-corner hack in iced_winit plus the
+    // card-filling-the-window layout make the default opaque theme clear
+    // color invisible, so we keep the iced default.
+    let builder = daemon(
         app::Snapdash::boot,
         app::Snapdash::update,
         app::Snapdash::view,
     )
-    .style(app::Snapdash::style)
-    .subscription(app::Snapdash::subscription)
-    .run()
+    .subscription(app::Snapdash::subscription);
+
+    #[cfg(target_os = "linux")]
+    let builder = builder.style(app::Snapdash::style);
+
+    builder.run()
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,5 +2,6 @@ pub mod chrome;
 pub mod components;
 pub mod entity_window;
 pub mod format;
+pub mod platform;
 pub mod settings;
 pub mod theme;

--- a/src/ui/platform/linux.rs
+++ b/src/ui/platform/linux.rs
@@ -1,0 +1,40 @@
+//! Linux platform bits. See `super` module doc for the big picture.
+
+use iced::{Element, Length};
+
+use crate::app::Message;
+
+/// Transparent margin around the card reserved for the iced-wgpu drop shadow
+/// to fade into. Must be >= `shadow.blur_radius + |shadow.offset|` of the
+/// largest theme shadow.
+///
+/// Current themes: `blur_radius` 20–22, `offset.y` 10 → 32 covers every side
+/// with 0–10 px headroom. Bump if the theme shadow grows.
+pub const SHADOW_MARGIN: f32 = 32.0;
+
+/// Window surface size for a given card size.
+///
+/// On Linux we enlarge the surface by `SHADOW_MARGIN` on each side so the
+/// shader-rendered drop shadow has transparent space to fade into, instead
+/// of being clipped at the window edge and showing up as jagged "corner
+/// triangles".
+pub fn window_size(card_width: f32, card_height: f32) -> iced::Size {
+    iced::Size::new(
+        card_width + 2.0 * SHADOW_MARGIN,
+        card_height + 2.0 * SHADOW_MARGIN,
+    )
+}
+
+/// Wraps the window's content in a transparent `SHADOW_MARGIN` padding.
+///
+/// The iced-wgpu quad shader draws the card's drop shadow in this margin
+/// area; clearing the surface to `Color::TRANSPARENT` (see
+/// `Snapdash::style`) lets the compositor blend those semi-transparent
+/// shadow pixels with the desktop.
+pub fn wrap_outer<'a>(inner: Element<'a, Message>) -> Element<'a, Message> {
+    iced::widget::container(inner)
+        .padding(SHADOW_MARGIN)
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into()
+}

--- a/src/ui/platform/mod.rs
+++ b/src/ui/platform/mod.rs
@@ -1,0 +1,32 @@
+//! Platform-specific window sizing and chrome wrapping.
+//!
+//! Different OSes handle transparent frameless windows differently:
+//!
+//! - **macOS / Windows**: OS-level hacks in iced_winit (`CALayer.cornerRadius +
+//!   masksToBounds`, `SetWindowRgn`) clip the window to a rounded shape, and
+//!   the platform's WindowServer/DWM renders its own native drop shadow around
+//!   that shape. The card fills the window edge-to-edge. The iced-side shader
+//!   shadow is effectively invisible (it has nowhere to render since the card
+//!   covers everything). Clear color can stay at the theme default.
+//!
+//! - **Linux (X11 / Wayland)**: There's no OS-level rounding hack that works
+//!   well — XShape gives 1-bit jagged masks, and the compositor won't add a
+//!   drop shadow to an undecorated transparent window for us. Instead we make
+//!   the window surface LARGER than the visible card by [`SHADOW_MARGIN`] on
+//!   every side, wrap the content in a transparent padding, and let the
+//!   iced wgpu shader render its own anti-aliased rounded corners and drop
+//!   shadow into the margin. The compositor then blends the margin's alpha
+//!   with the desktop. This is how GTK4/libadwaita apps do it.
+//!
+//! Both branches expose the same small API ([`window_size`], [`wrap_outer`])
+//! so `app.rs` stays platform-agnostic at the call sites.
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+pub use linux::*;
+
+#[cfg(not(target_os = "linux"))]
+mod native;
+#[cfg(not(target_os = "linux"))]
+pub use native::*;

--- a/src/ui/platform/native.rs
+++ b/src/ui/platform/native.rs
@@ -1,0 +1,26 @@
+//! macOS / Windows platform bits. See `super` module doc for the big picture.
+//!
+//! Both platforms rely on OS-level hacks in iced_winit (`CALayer.cornerRadius
+//! and masksToBounds` on macOS, `SetWindowRgn` on Windows) to clip the window
+//! surface to a rounded rectangle, with a platform-native drop shadow rendered
+//! by WindowServer / DWM outside the clipped region. The card fills the
+//! window edge-to-edge and the iced-side shader shadow is not used.
+//!
+//! The helpers here are therefore pass-throughs that keep `app.rs` tidy.
+
+use iced::Element;
+
+use crate::app::Message;
+
+/// Window surface size for a given card size.
+///
+/// On macOS/Windows the surface is exactly the card size — the OS clips the
+/// outer edge to a rounded shape and provides the drop shadow itself.
+pub fn window_size(card_width: f32, card_height: f32) -> iced::Size {
+    iced::Size::new(card_width, card_height)
+}
+
+/// Pass-through. The card already fills the window; no extra outer margin.
+pub fn wrap_outer<'a>(inner: Element<'a, Message>) -> Element<'a, Message> {
+    inner
+}


### PR DESCRIPTION
On Linux, transparent borderless widget windows now size their
surface to `card + 2 * SHADOW_MARGIN`, wrap the visible content
in a transparent padding, and install a `style()` hook that
clears the surface to `Color::TRANSPARENT`. The iced-wgpu
shader renders the drop shadow into that margin and the
compositor blends the alpha fade with the desktop — the same
approach GTK4/libadwaita use. Fixes both the jagged "cranky"
corner edges and the opaque-theme-bg corner triangles
previously seen on GNOME/Mutter.

Platform-specific bits live in a new `src/ui/platform/`
module behind a tiny shared API (`window_size`, `wrap_outer`):

* `linux.rs` — defines `SHADOW_MARGIN`, enlarges the window
  and wraps the content in transparent padding.
* `native.rs` — pass-through no-ops for macOS / Windows,
  where OS-level hacks in iced_winit clip the window to a
  rounded shape and the OS draws its own drop shadow.

`Snapdash::style` is `#[cfg(target_os = "linux")]` and
`main.rs` only wires `.style(...)` into the daemon builder on
Linux, so macOS and Windows keep the iced default clear color
and the pre-existing "nice and optimal" look — the card fills
the window edge-to-edge and the OS-drawn shadow lives outside
the surface.