### PR TITLE
feat(ui): Added update status indicator to `Settings` windows and widgets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "snapdash"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snapdash"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 authors = ["Lukáš Svoboda <opensource@schizza.cz>"]
 license = "Apache-2.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use crate::ha::{EntityState, HaConnectionConfig, HaEvent};
-use crate::logger as log;
 use crate::logger::LogType;
+use crate::{logger as log, update};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant};
 
@@ -78,6 +78,13 @@ pub enum FocusDirection {
     Previous,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum UpdateState {
+    Unknown,
+    UptoDate,
+    UpdateAvailable,
+}
+
 #[derive(Debug)]
 pub struct Snapdash {
     pub config: Config,
@@ -103,6 +110,7 @@ pub struct Snapdash {
 
     pub entity_search_query: String,
     pub debug_now: Instant,
+    pub update_state: UpdateState,
 }
 
 #[derive(Debug, Clone)]
@@ -145,6 +153,8 @@ pub enum Message {
     },
 
     EntitySearchChanged(String),
+    CheckForUpdate,
+    LastVersionChecked(Option<update::GitHubRelease>),
 }
 
 impl Snapdash {
@@ -167,6 +177,7 @@ impl Snapdash {
             active_settings_sensors: Vec::new(),
             entity_search_query: String::new(),
             debug_now: Instant::now(),
+            update_state: UpdateState::Unknown,
         }
     }
     pub fn boot() -> (Self, Task<Message>) {
@@ -177,7 +188,11 @@ impl Snapdash {
             Message::ConfigLoad,
         );
 
-        (state, load_task)
+        let check_update = Task::perform(update::get_latest_version(), Message::LastVersionChecked);
+
+        let tasks = Task::batch([load_task, check_update]);
+
+        (state, tasks)
     }
 
     fn rebuild_active_settings_sensors(&mut self) {
@@ -283,11 +298,15 @@ impl Snapdash {
             })
         });
 
+        let check_for_update =
+            iced::time::every(Duration::from_hours(1)).map(|_| Message::CheckForUpdate);
+
         Subscription::batch([
             window::close_events().map(Message::WindowClosed),
             redraw_events,
             keyboard_events,
             ha,
+            check_for_update,
         ])
     }
 
@@ -781,6 +800,20 @@ impl Snapdash {
             Message::WindowRedraw(id, now) => {
                 self.handle_redraw_requested(id, now);
                 Task::none()
+            }
+
+            Message::CheckForUpdate => {
+                Task::perform(update::get_latest_version(), Message::LastVersionChecked)
+            }
+
+            Message::LastVersionChecked(release) => {
+                if release.is_some() {
+                    self.update_state = UpdateState::UpdateAvailable;
+                    Task::none()
+                } else {
+                    self.update_state = UpdateState::UptoDate;
+                    Task::none()
+                }
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod logger;
 mod secrets;
 mod theme;
 mod ui;
+mod update;
 
 use iced::daemon;
 

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -6,7 +6,7 @@ use iced::{Alignment, Element, Length};
 #[cfg(feature = "diagnostics")]
 use iced::{Background, Border};
 
-use crate::app::{Message, WindowKind, WindowState};
+use crate::app::{Message, UpdateState, WindowKind, WindowState};
 use crate::ui::theme::{UiTheme, icon_button, icon_text};
 
 /// Returns window content based on its kind (`Settings` / `Entity`).
@@ -17,9 +17,12 @@ pub fn window_content<'a>(
 ) -> Element<'a, Message> {
     match &win.kind {
         WindowKind::Settings => crate::ui::settings::view(app, id),
-        WindowKind::Entity { .. } => {
-            crate::ui::entity_window::view(&win.entity, app.theme.palette(), app.ha_connected)
-        }
+        WindowKind::Entity { .. } => crate::ui::entity_window::view(
+            &win.entity,
+            app.theme.palette(),
+            app.ha_connected,
+            app.update_state == UpdateState::UpdateAvailable,
+        ),
     }
 }
 

--- a/src/ui/components.rs
+++ b/src/ui/components.rs
@@ -257,6 +257,26 @@ pub fn section(label: &'static str, p: Palette) -> text::Text<'static> {
 //     text(label.into()).color(p.text_secondary).size(14)
 // }
 
+pub fn badge<'a>(label: impl Into<String>, p: Palette) -> Element<'a, Message> {
+    container(
+        text(label.into())
+            .size(11)
+            .style(move |_: &iced::Theme| iced::widget::text::Style {
+                color: Some(p.accent),
+            }),
+    )
+    .padding([3, 10])
+    .style(move |_| container::Style {
+        background: Some(Background::Color(p.accent_tint)),
+        border: Border {
+            radius: 999.0.into(),
+            width: 1.0,
+            color: p.accent,
+        },
+        ..Default::default()
+    })
+    .into()
+}
 pub fn dimmed<S: Into<String>>(label: S, p: Palette) -> text::Text<'static> {
     text(label.into()).color(p.text_dim).size(10)
 }

--- a/src/ui/entity_window.rs
+++ b/src/ui/entity_window.rs
@@ -57,21 +57,44 @@ fn pulse_border(p: Palette, pulse: f32) -> iced::Color {
     }
 }
 
-pub fn view(state: &EntityWindowState, p: Palette, connected: bool) -> Element<'_, Message> {
+pub fn view(
+    state: &EntityWindowState,
+    p: Palette,
+    connected: bool,
+    update: bool,
+) -> Element<'_, Message> {
     let (friendly, main_opt, detail) = format_main_value(state);
 
-    let title_text = if let Some(name) = friendly {
-        text(name)
-            .size(14)
-            .style(move |_: &iced::Theme| iced::widget::text::Style {
-                color: Some(p.text_secondary),
-            })
+    let update_icon = if update {
+        components::dimmed(
+            '⟳',
+            crate::theme::Palette {
+                text_dim: iced::Color::from_rgb8(255, 0, 0),
+                ..p
+            },
+        )
     } else {
-        text(pretty_name(&state.entity_id))
-            .size(14)
-            .style(move |_: &iced::Theme| iced::widget::text::Style {
-                color: Some(p.text_secondary),
-            })
+        components::dimmed("", p)
+    };
+    let title_text = if let Some(name) = friendly {
+        row![
+            column![text(name).size(14).style(move |_: &iced::Theme| {
+                iced::widget::text::Style {
+                    color: Some(p.text_secondary),
+                }
+            }),]
+            .width(iced::Fill),
+            update_icon
+        ]
+    } else {
+        row![
+            text(pretty_name(&state.entity_id))
+                .size(14)
+                .style(move |_: &iced::Theme| iced::widget::text::Style {
+                    color: Some(p.text_secondary),
+                }),
+            update_icon
+        ]
     };
 
     let main = main_opt.unwrap_or_else(|| "-".into());

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -3,9 +3,10 @@ use iced::widget::checkbox;
 use iced::widget::{column, container, mouse_area, row};
 use iced::{Element, Length};
 
-use crate::app::{Message, Snapdash};
+use crate::app::{Message, Snapdash, UpdateState};
 use crate::theme::metric;
 use crate::ui::components::{active_sensor_section, dimmed, sensors_section};
+use crate::update;
 
 use super::components;
 
@@ -35,6 +36,39 @@ pub fn view(snap: &Snapdash, id: iced::window::Id) -> Element<'_, Message> {
     } else {
         dimmed("Status", p).into()
     };
+
+    let update_icon = match snap.update_state {
+        UpdateState::Unknown => dimmed(
+            '?',
+            crate::theme::Palette {
+                text_dim: iced::Color::from_rgb8(0, 0, 255),
+                ..p
+            },
+        ),
+        UpdateState::UptoDate => dimmed(
+            '✓',
+            crate::theme::Palette {
+                text_dim: iced::Color::from_rgb8(0, 255, 0),
+                ..p
+            },
+        ),
+        UpdateState::UpdateAvailable => dimmed(
+            '⟳',
+            crate::theme::Palette {
+                text_dim: iced::Color::from_rgb8(255, 0, 0),
+                ..p
+            },
+        ),
+    };
+
+    let version: Element<Message> = row![
+        dimmed(format!("version: {} ", update::CURRENT_VERSION), p,),
+        update_icon
+    ]
+    .padding([4, 0])
+    // .align_x(iced::Alignment::End)
+    .into();
+
     let search: Element<Message> =
         components::mac_input("Search entities ...", &snap.entity_search_query, p)
             .on_input(Message::EntitySearchChanged)
@@ -106,6 +140,11 @@ pub fn view(snap: &Snapdash, id: iced::window::Id) -> Element<'_, Message> {
                 .padding([4, 0])
         )
         .on_press(Message::StartDrag(id)),
+        if snap.update_state == UpdateState::UpdateAvailable {
+            components::badge("Update Available", p)
+        } else {
+            iced::widget::space().width(0).height(0).into()
+        },
         components::icon("✕", p, Some(Message::CloseWindow(id))),
     ]
     .spacing(metric::GAP)
@@ -121,7 +160,12 @@ pub fn view(snap: &Snapdash, id: iced::window::Id) -> Element<'_, Message> {
     .align_y(iced::Alignment::Center)
     .into();
 
-    let status_row: Element<Message> = row![status].into();
+    let status_row: Element<Message> = row![
+        column![status].width(iced::Length::Fill),
+        column![version].align_x(iced::Alignment::End)
+    ]
+    .width(iced::Fill)
+    .into();
 
     let mut content = column![title_bar, iced::widget::space().height(2),]
         .spacing(14)

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,31 @@
+use serde::Deserialize;
+
+pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct GitHubRelease {
+    tag_name: String,
+    // html_url: String,   //intentionaly left here for future useage.
+}
+
+pub async fn get_latest_version() -> Option<GitHubRelease> {
+    let client = reqwest::Client::new();
+
+    let release: GitHubRelease = client
+        .get("https://api.github.com/repos/schizza/snapdash/releases/latest")
+        .header("User-Agent", "snapdash")
+        .send()
+        .await
+        .ok()?
+        .json()
+        .await
+        .ok()?;
+
+    let latest = release.tag_name.trim_start_matches('v');
+
+    if latest != CURRENT_VERSION {
+        Some(release)
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
## Summary

Added `badge` to `Snapdash settings` window and a little `update` indicator to widgets.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] Documentation
- [ ] Refactor / maintenance
- [X] UI / visual change
- [ ] Performance improvement
- [ ] Test

## Testing

- [X] Tested on macOS
- [ ] Tested on Windows
- [X] Tested on Linux
- [X] `cargo build --release` succeeds
- [X] `cargo clippy` has no new warnings

## Screenshots / recordings
 
<img width="1732" height="271" alt="CleanShot 2026-04-19 at 11 34 43@2x" src="https://github.com/user-attachments/assets/2a27d278-c2b9-47a1-bf01-864c68036e25" />
<img width="572" height="412" alt="CleanShot 2026-04-19 at 11 37 43@2x" src="https://github.com/user-attachments/assets/1544353f-26ff-4b21-be40-fbd8511f5460" />

## Checklist

- [X] PR targets `dev` branch (not `main`)
- [X] Commits follow conventional format (`feat:`, `fix:`, `docs:`, ...)
- [X] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] I've added/updated tests where applicable
