### PR TITLE
fix(ha-ws): detect stale WebScocked connections after sleep/awake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@
   .env.local
   *.pem
   *.key
+
+target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3759,7 +3759,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,12 @@ reqwest = { version = "0.13.2", default-features = false, features = [
 ] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-tokio = { version = "1.48.0", features = ["rt-multi-thread", "time", "fs"] }
+tokio = { version = "1.48.0", features = [
+  "macros",
+  "rt-multi-thread",
+  "time",
+  "fs",
+] }
 tokio-tungstenite = { version = "0.29.0", features = [
   "rustls-tls-webpki-roots",
 ] }

--- a/src/ha/ws.rs
+++ b/src/ha/ws.rs
@@ -4,7 +4,7 @@ use iced::futures::{SinkExt, StreamExt};
 use iced::stream;
 use serde_json::json;
 use std::time::Duration;
-use tokio::time::sleep;
+use tokio::time::{Instant, interval, sleep};
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 use tokio_tungstenite::tungstenite::Utf8Bytes;
 
@@ -135,20 +135,53 @@ pub fn connect(config: &HaConnectionConfig) -> iced::futures::stream::BoxStream<
             let initial_states = rest::fetch_all_states(ha_url.clone(), token.clone()).await;
             let _ = output.send(HaEvent::InitialState(initial_states)).await;
 
-            while let Some(msg) = stream.next().await {
-                let Ok(msg) = msg else { continue };
-                let Ok(text) = msg.to_text() else { continue };
+            let mut heartbeat = interval(Duration::from_secs(30));
+            let mut last_received = Instant::now();
 
-                if let Ok(parsed) = serde_json::from_str::<Incoming>(text)
-                    && parsed.r#type == "event"
-                    && let Some(ev) = parsed.event
-                    && ev.event_type == "state_changed"
-                    && let Some(data) = ev.data
-                    && let Some(new_state) = data.new_state
-                {
-                    let _ = output.send(HaEvent::StateChanged { new_state }).await;
+            loop {
+                tokio::select! {
+                    msg = stream.next() => {
+                        let Some(msg) = msg else { break };
+                        let Ok(msg) = msg else { continue };
+
+                        last_received = Instant::now();
+
+                        let Ok(text) = msg.to_text() else { continue };
+
+                        if let Ok(parsed) = serde_json::from_str::<Incoming>(text)
+                        && parsed.r#type == "event"
+                        && let Some(ev) = parsed.event
+                        && ev.event_type == "state_changed"
+                        && let Some(data) = ev.data
+                        && let Some(new_state) = data.new_state
+                        {
+                            let _ = output.send(HaEvent::StateChanged { new_state}).await;
+                        }
+                    }
+                    _ = heartbeat.tick() => {
+                            if last_received.elapsed() > Duration::from_secs(90) {
+                                break;
+                            }
+                            if sink.send(WsMessage::Ping(vec![].into())).await.is_err()
+                            { break; }
+                        }
                 }
             }
+
+            // while let Some(msg) = stream.next().await {
+            //     let Ok(msg) = msg else { continue };
+            //     let Ok(text) = msg.to_text() else { continue };
+            //
+            //     if let Ok(parsed) = serde_json::from_str::<Incoming>(text)
+            //         && parsed.r#type == "event"
+            //         && let Some(ev) = parsed.event
+            //         && ev.event_type == "state_changed"
+            //         && let Some(data) = ev.data
+            //         && let Some(new_state) = data.new_state
+            //     {
+            //         let _ = output.send(HaEvent::StateChanged { new_state }).await;
+            //     }
+            // }
 
             let _ = output.send(HaEvent::Disconnected("ws closed".into())).await;
             sleep(Duration::from_secs(2)).await;

--- a/src/ha/ws.rs
+++ b/src/ha/ws.rs
@@ -168,21 +168,6 @@ pub fn connect(config: &HaConnectionConfig) -> iced::futures::stream::BoxStream<
                 }
             }
 
-            // while let Some(msg) = stream.next().await {
-            //     let Ok(msg) = msg else { continue };
-            //     let Ok(text) = msg.to_text() else { continue };
-            //
-            //     if let Ok(parsed) = serde_json::from_str::<Incoming>(text)
-            //         && parsed.r#type == "event"
-            //         && let Some(ev) = parsed.event
-            //         && ev.event_type == "state_changed"
-            //         && let Some(data) = ev.data
-            //         && let Some(new_state) = data.new_state
-            //     {
-            //         let _ = output.send(HaEvent::StateChanged { new_state }).await;
-            //     }
-            // }
-
             let _ = output.send(HaEvent::Disconnected("ws closed".into())).await;
             sleep(Duration::from_secs(2)).await;
         }


### PR DESCRIPTION
## Summary

Replace the blocking while-let read loop with a tokio::select! loop that sends WebSocket pings every 30s and tracks time since last received message. If no data arrives for 90s (3 missed heartbeats), the connection is considered dead and trigger a reconnect.

Fixes the bug where widgets showed "connected" after sleep/awake despite the TCP connection being silently dropped. The same fix also covers HA restarts, WiFi drops, and router reboots.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] UI / visual change
- [ ] Performance improvement

## Related issues

 Fixes #18

  <!-- How did you verify this works? -->

- [X] Tested on macOS
- [X] `cargo build --release` succeeds
- [X] `cargo clippy` has no new warnings