### PR TITLE
fix(ha-ws): stop reconnect loop after repeated auth failures

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -419,6 +419,15 @@ impl Snapdash {
             HaEvent::StateChanged { new_state } => {
                 self.apply_entity_state(new_state);
             }
+            HaEvent::AuthFailed(why) => {
+                self.ha_connected = false;
+                self.ha_connection = None;
+                self.config.ha_token_present = false;
+
+                self.set_status(format!("Authentication failed: {why}"), LogType::Error);
+                let cfg = self.config.clone();
+                tokio::spawn(async move { cfg.save_async().await });
+            }
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -426,7 +426,9 @@ impl Snapdash {
 
                 self.set_status(format!("Authentication failed: {why}"), LogType::Error);
                 let cfg = self.config.clone();
-                tokio::spawn(async move { cfg.save_async().await });
+                let _ = Task::perform(async move { cfg.save_async().await }, |_| {
+                    Message::SaveConfig
+                });
             }
         }
     }

--- a/src/ha/types.rs
+++ b/src/ha/types.rs
@@ -22,6 +22,7 @@ pub enum HaEvent {
     Disconnected(String),
     InitialState(Vec<EntityState>),
     StateChanged { new_state: EntityState },
+    AuthFailed(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/ha/ws.rs
+++ b/src/ha/ws.rs
@@ -49,7 +49,22 @@ pub fn connect(config: &HaConnectionConfig) -> iced::futures::stream::BoxStream<
     let token = config.token.clone();
 
     stream::channel(100, async move |mut output| {
+        let mut auth_failures: u8 = 0;
+        let mut connect_backoff = Duration::from_secs(2);
+        const MAX_AUTH_FAILURES: u8 = 2;
+        const MAX_BACKOFF: Duration = Duration::from_secs(60);
+
         loop {
+            if auth_failures >= MAX_AUTH_FAILURES {
+                let _ = output
+                .send(HaEvent::AuthFailed(format!("Authentication failed {auth_failures} times - stopped retrying. Check your token.")))
+                .await;
+
+                loop {
+                    sleep(Duration::from_secs(3600)).await;
+                }
+            }
+
             let ws_url = ws_url_from_http(&ha_url);
 
             let (ws, _resp) = match tokio_tungstenite::connect_async(&ws_url).await {
@@ -58,7 +73,8 @@ pub fn connect(config: &HaConnectionConfig) -> iced::futures::stream::BoxStream<
                     let _ = output
                         .send(HaEvent::Disconnected(format!("connect: {e}")))
                         .await;
-                    sleep(Duration::from_secs(3)).await;
+                    sleep(connect_backoff).await;
+                    connect_backoff = (connect_backoff * 2).min(MAX_BACKOFF);
                     continue;
                 }
             };
@@ -96,12 +112,14 @@ pub fn connect(config: &HaConnectionConfig) -> iced::futures::stream::BoxStream<
 
                 if text.contains("\"auth_ok\"") {
                     authed = true;
+                    auth_failures = 0;
                     break;
                 }
 
                 if text.contains("\"auth_invalid\"") {
+                    auth_failures += 1;
                     let _ = output
-                        .send(HaEvent::Disconnected("auth_invalid".into()))
+                        .send(HaEvent::Disconnected(format!("auth_invalid (attempt {auth_failures}/{MAX_AUTH_FAILURES}")))
                         .await;
                     break;
                 }
@@ -131,6 +149,7 @@ pub fn connect(config: &HaConnectionConfig) -> iced::futures::stream::BoxStream<
             }
 
             let _ = output.send(HaEvent::Connected).await;
+            connect_backoff = Duration::from_secs(2);
 
             let initial_states = rest::fetch_all_states(ha_url.clone(), token.clone()).await;
             let _ = output.send(HaEvent::InitialState(initial_states)).await;


### PR DESCRIPTION
## Summary

  Track consecutive auth_invalid responses and stop
  retrying after 2 failed attempts. Sends AuthFailed
  event to the app which clears the connection,
  marks token as invalid, and displays an error prompting
  the user to re-enter their token.

  Prevents Home Assistant from IP-banning Snapdash due
  to rapid repeated authentication failures
  (HA bans after 6 attempts).

  Also adds optional exponential backoff for
  connection errors (2s → 4s → 8s → ... → 60s max)
  to reduce log noise during prolonged HA outages.

## Type of change

<!-- Check all that apply -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] Documentation
- [ ] Refactor / maintenance
- [ ] UI / visual change
- [ ] Performance improvement
- [ ] Test

## Related issues

Closes #17 

## Testing


