### PR TITLE
refactor(ha-ws): rewrite as typed state machine with tagged wire format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd63e33452ffdafd39924c4f05a5dd1e94db646c779c6bd59148a3d95fff5ad4"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "x11rb",
 ]
 
@@ -1513,7 +1513,7 @@ dependencies = [
  "iced_runtime",
  "iced_widget",
  "iced_winit",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1529,7 +1529,7 @@ dependencies = [
  "num-traits",
  "rustc-hash 2.1.1",
  "smol_str",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "web-time",
 ]
 
@@ -1571,7 +1571,7 @@ dependencies = [
  "log",
  "raw-window-handle",
  "rustc-hash 2.1.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicode-segmentation",
 ]
 
@@ -1593,7 +1593,7 @@ dependencies = [
  "iced_tiny_skia",
  "iced_wgpu",
  "log",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1605,7 +1605,7 @@ dependencies = [
  "iced_core",
  "iced_futures",
  "raw-window-handle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1639,7 +1639,7 @@ dependencies = [
  "iced_graphics",
  "log",
  "rustc-hash 2.1.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wgpu",
 ]
 
@@ -1652,7 +1652,7 @@ dependencies = [
  "log",
  "num-traits",
  "rustc-hash 2.1.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicode-segmentation",
 ]
 
@@ -1670,7 +1670,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-quartz-core 0.3.2",
  "rustc-hash 2.1.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2114,7 +2114,7 @@ dependencies = [
  "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicode-ident",
 ]
 
@@ -2871,7 +2871,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2893,7 +2893,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3012,7 +3012,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3442,7 +3442,7 @@ dependencies = [
  "log",
  "memmap2",
  "rustix 1.1.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -3487,9 +3487,11 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "toml",
+ "url",
 ]
 
 [[package]]
@@ -3656,11 +3658,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3676,9 +3678,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3980,7 +3982,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4044,9 +4046,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4424,7 +4426,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
  "wgpu-core-deps-windows-linux-android",
@@ -4500,7 +4502,7 @@ dependencies = [
  "raw-window-handle",
  "renderdoc-sys",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -4518,7 +4520,7 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "web-sys",
 ]
 
@@ -4564,7 +4566,7 @@ dependencies = [
  "clipboard_wayland",
  "clipboard_x11",
  "raw-window-handle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ anyhow = "1.0.100"
 chrono = { version = "0.4.42", default-features = false, features = ["clock"] }
 iced = { version = "0.14.0", features = ["wgpu", "tokio"] }
 directories = "6.0.0"
+thiserror = "2.0.18"
 
 reqwest = { version = "0.13.2", default-features = false, features = [
   "json",
@@ -53,6 +54,7 @@ tokio-tungstenite = { version = "0.29.0", features = [
   "rustls-tls-webpki-roots",
 ] }
 toml = "1.1.2"
+url = "2.5.8"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "3.6.3", features = ["apple-native"] }

--- a/src/ha/rest.rs
+++ b/src/ha/rest.rs
@@ -1,7 +1,7 @@
 use crate::ha::types::EntityState;
 
-pub async fn fetch_all_states(ha_url: String, token: String) -> Vec<EntityState> {
-    let base = ha_url.trim_end_matches("/");
+pub async fn fetch_all_states(ha_url: &str, token: &str) -> Vec<EntityState> {
+    let base = ha_url.trim_end_matches('/');
 
     let client = reqwest::Client::new();
 

--- a/src/ha/types.rs
+++ b/src/ha/types.rs
@@ -1,7 +1,35 @@
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum HaError {
+    #[error("connection failed: {0}")]
+    Connect(String),
+
+    #[error("authentication rejected by server: {0}")]
+    AuthInvalid(String),
+
+    #[error("authentication failed after {attempts} attempts - check your token")]
+    AuthExhausted { attempts: u8 },
+
+    #[error("websocket closed")]
+    Closed,
+
+    #[error("connection went stale (no frames for {elapsed:?})")]
+    Stale { elapsed: Duration },
+
+    #[error("protocol error: {0}")]
+    Protocol(String),
+
+    #[error("timeout waiting for: {what}")]
+    Timeout { what: &'static str },
+
+    #[error("failed to send: {what}")]
+    SendFailed { what: &'static str },
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EntityState {
@@ -19,10 +47,10 @@ pub struct EntityState {
 #[derive(Clone, Debug)]
 pub enum HaEvent {
     Connected,
-    Disconnected(String),
+    Disconnected(HaError),
     InitialState(Vec<EntityState>),
     StateChanged { new_state: EntityState },
-    AuthFailed(String),
+    AuthFailed(HaError),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/ha/ws.rs
+++ b/src/ha/ws.rs
@@ -1,195 +1,324 @@
-use crate::ha::types::{EntityState, HaEvent};
+use crate::ha::types::{EntityState, HaError, HaEvent};
 use crate::ha::{HaConnectionConfig, rest};
+use iced::futures::stream::BoxStream;
 use iced::futures::{SinkExt, StreamExt};
 use iced::stream;
-use serde_json::json;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::time::Duration;
 use tokio::time::{Instant, interval, sleep};
-use tokio_tungstenite::tungstenite::Message as WsMessage;
-use tokio_tungstenite::tungstenite::Utf8Bytes;
+use tokio_tungstenite::tungstenite::{Bytes, Message as WsMessage, Utf8Bytes};
+use url::Url;
 
-#[derive(Debug, serde::Deserialize)]
-struct Incoming {
-    #[serde(default)]
-    r#type: String,
+type Ws =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+type WsSink = iced::futures::stream::SplitSink<Ws, WsMessage>;
+type WsStream = iced::futures::stream::SplitStream<Ws>;
 
-    #[serde(default)]
-    event: Option<EventPayload>,
+const INITIAL_BACKOFF: Duration = Duration::from_secs(2);
+const MAX_BACKOFF: Duration = Duration::from_secs(60);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+const STALE_AFTER: Duration = Duration::from_secs(90);
+const AUTH_RETRY_DELAY: Duration = Duration::from_secs(2);
+const RECONNECT_DELAY: Duration = Duration::from_secs(2);
+const MAX_AUTH_FAILURES: u8 = 2;
+const EVENT_CHANNEL_CAPACITY: usize = 100;
+const SUBSCRIBE_ID: u64 = 1;
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[expect(
+    dead_code,
+    reason = "fields kept for Debug output and wire-contract symmetry"
+)]
+enum ServerMsg {
+    AuthRequired {
+        #[serde(default)]
+        ha_version: String,
+    },
+    AuthOk {
+        #[serde(default)]
+        ha_version: String,
+    },
+    AuthInvalid {
+        #[serde(default)]
+        message: String,
+    },
+    Event {
+        #[serde(default)]
+        id: Option<u64>,
+        event: EventPayload,
+    },
+    Result {
+        id: u64,
+        success: bool,
+        #[serde(default)]
+        error: Option<serde_json::Value>,
+    },
+    Pong {
+        id: u64,
+    },
+
+    #[serde(other)]
+    Other,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ClientMsg<'a> {
+    Auth { access_token: &'a str },
+    SubscribeEvents { id: u64, event_type: &'a str },
+}
+
+#[derive(Debug, Deserialize)]
 struct EventPayload {
-    #[serde(default)]
     event_type: String,
     #[serde(default)]
-    data: Option<EventData>,
+    data: EventData,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 struct EventData {
     #[serde(default)]
     new_state: Option<EntityState>,
 }
 
-fn ws_url_from_http(ha_url: &str) -> String {
-    // http(s)://host -> ws(s)://host/api/websocket
-    let base = ha_url.trim_end_matches('/');
-    if let Some(rest) = base.strip_prefix("https://") {
-        format!("wss://{rest}/api/websocket")
-    } else if let Some(rest) = base.strip_prefix("http://") {
-        format!("ws://{rest}/api/websocket")
+fn ws_url_from_http(ha_url: &str) -> Result<Url, HaError> {
+    let mut url = Url::parse(ha_url).map_err(|e| HaError::Protocol(format!("invalid URL: {e}")))?;
+
+    let ws_scheme = match url.scheme() {
+        "https" => "wss",
+        "http" => "ws",
+        other => {
+            return Err(HaError::Protocol(format!(
+                "expected http(s):// URL, got scheme {other:?}"
+            )));
+        }
+    };
+
+    url.set_scheme(ws_scheme)
+        .map_err(|()| HaError::Protocol("failed to switch URL scheme to WebSocket".into()))?;
+
+    let base = url.path().trim_matches('/');
+    let new_path = if base.is_empty() {
+        "/api/websocket".to_owned()
     } else {
-        // fallback: assume https
-        format!("wss://{base}/api/websocket")
+        format!("/{base}/api/websocket")
+    };
+
+    url.set_path(&new_path);
+    Ok(url)
+}
+
+async fn open_session(token: &str, ws_url: &Url) -> Result<(WsSink, WsStream), HaError> {
+    let (ws, _) = tokio_tungstenite::connect_async(ws_url.as_str())
+        .await
+        .map_err(|e| HaError::Connect(e.to_string()))?;
+
+    let (mut sink, mut stream) = ws.split();
+
+    handshake(&mut sink, &mut stream, token).await?;
+    subscribe(&mut sink).await?;
+
+    Ok((sink, stream))
+}
+
+async fn send_msg(
+    sink: &mut WsSink,
+    msg: &ClientMsg<'_>,
+    what: &'static str,
+) -> Result<(), HaError> {
+    let json = serde_json::to_string(msg).map_err(|e| HaError::Protocol(e.to_string()))?;
+
+    sink.send(WsMessage::Text(Utf8Bytes::from(json)))
+        .await
+        .map_err(|_| HaError::SendFailed { what })
+}
+
+async fn read_msg<T: serde::de::DeserializeOwned>(stream: &mut WsStream) -> Result<T, HaError> {
+    loop {
+        match stream.next().await {
+            Some(Err(e)) => return Err(HaError::Protocol(e.to_string())),
+            Some(Ok(WsMessage::Close(_))) | None => return Err(HaError::Closed),
+            Some(Ok(WsMessage::Text(text))) => {
+                return serde_json::from_str(text.as_str())
+                    .map_err(|e| HaError::Protocol(e.to_string()));
+            }
+            // binary, ping, pong -- tungsteinite will respond on his own
+            Some(Ok(_)) => {}
+        }
     }
 }
 
-pub fn connect(config: &HaConnectionConfig) -> iced::futures::stream::BoxStream<'static, HaEvent> {
-    let ha_url = config.url.clone();
-    let token = config.token.clone();
+async fn expect<T: DeserializeOwned>(
+    stream: &mut WsStream,
+    timeout_dur: Duration,
+    what: &'static str,
+) -> Result<T, HaError> {
+    tokio::time::timeout(timeout_dur, read_msg(stream))
+        .await
+        .map_err(|_| HaError::Timeout { what })?
+}
 
-    stream::channel(100, async move |mut output| {
-        let mut auth_failures: u8 = 0;
-        let mut connect_backoff = Duration::from_secs(2);
-        const MAX_AUTH_FAILURES: u8 = 2;
-        const MAX_BACKOFF: Duration = Duration::from_secs(60);
+async fn handshake(sink: &mut WsSink, stream: &mut WsStream, token: &str) -> Result<(), HaError> {
+    // expect auth_required
+    match expect::<ServerMsg>(stream, HANDSHAKE_TIMEOUT, "auth_required").await? {
+        ServerMsg::AuthRequired { .. } => {}
+        other => {
+            return Err(HaError::Protocol(format!(
+                "expected auth_required, got {other:?}"
+            )));
+        }
+    }
 
-        loop {
-            if auth_failures >= MAX_AUTH_FAILURES {
-                let _ = output
-                .send(HaEvent::AuthFailed(format!("Authentication failed {auth_failures} times - stopped retrying. Check your token.")))
-                .await;
+    // send auth
+    send_msg(
+        sink,
+        &ClientMsg::Auth {
+            access_token: token,
+        },
+        "auth",
+    )
+    .await?;
 
-                loop {
-                    sleep(Duration::from_secs(3600)).await;
+    // expect auth_ok / auth_invalid
+    match expect::<ServerMsg>(stream, HANDSHAKE_TIMEOUT, "auth_result").await? {
+        ServerMsg::AuthOk { .. } => Ok(()),
+        ServerMsg::AuthInvalid { message } => Err(HaError::AuthInvalid(message)),
+        other => Err(HaError::Protocol(format!(
+            "unexpected during auth: {other:?}"
+        ))),
+    }
+}
+
+async fn subscribe(sink: &mut WsSink) -> Result<(), HaError> {
+    send_msg(
+        sink,
+        &ClientMsg::SubscribeEvents {
+            id: SUBSCRIBE_ID,
+            event_type: "state_changed",
+        },
+        "subscribe",
+    )
+    .await
+}
+
+async fn pump_events(
+    sink: &mut WsSink,
+    stream: &mut WsStream,
+    out: &mut iced::futures::channel::mpsc::Sender<HaEvent>,
+) -> HaError {
+    let mut heartbeat = interval(HEARTBEAT_INTERVAL);
+    let mut last_received = Instant::now();
+
+    loop {
+        tokio::select! {
+            // we have a payload
+            frame = stream.next() => {
+                let frame = match frame {
+                    None => return HaError::Closed,
+                    Some(Err(e)) => return HaError::Protocol(e.to_string()),
+                    Some(Ok(f)) => f,
+                };
+
+                last_received = Instant::now();
+
+                let text = match frame {
+                    WsMessage::Text(t) => t,
+                    WsMessage::Close(_) => return HaError::Closed,
+                    _ => continue,
+                };
+
+                let msg: ServerMsg = match serde_json::from_str(text.as_str()) {
+                    Ok(m) => m,
+                    Err(_) => {
+                        // consider to create tracing. Eg: tracing::warn!(error = %e, raw = %text.as_str(), "failed to decode ServerMsg");
+                        // but this is suitable for now
+                        // tracing::warn!(error = %e, raw = %text.as_str(), "failed to decode ServerMsg");
+                        continue;
+                    }
+                };
+
+                if let ServerMsg::Event { event, .. } = msg
+                    && event.event_type == "state_changed"
+                    && let Some(new_state) = event.data.new_state
+                {
+                    let _ = out.send(HaEvent::StateChanged { new_state }).await;
                 }
             }
 
-            let ws_url = ws_url_from_http(&ha_url);
+            _ = heartbeat.tick() => {
+                if last_received.elapsed() > STALE_AFTER {
+                    return HaError::Stale { elapsed: last_received.elapsed() };
+                }
+                if sink.send(WsMessage::Ping(Bytes::new())).await.is_err() {
+                    return HaError::SendFailed { what: "ping" };
+                }
+            }
+        }
+    }
+}
 
-            let (ws, _resp) = match tokio_tungstenite::connect_async(&ws_url).await {
-                Ok(v) => v,
+pub fn connect(config: &HaConnectionConfig) -> BoxStream<'static, HaEvent> {
+    let cfg = config.clone();
+
+    stream::channel(EVENT_CHANNEL_CAPACITY, async move |mut out| {
+        let ws_url = match ws_url_from_http(&cfg.url) {
+            Ok(u) => u,
+            Err(e) => {
+                let _ = out.send(HaEvent::Disconnected(e)).await;
+                return;
+            }
+        };
+
+        let mut auth_failures: u8 = 0;
+        let mut backoff = INITIAL_BACKOFF;
+
+        loop {
+            let (mut sink, mut stream) = match open_session(&cfg.token, &ws_url).await {
+                Ok(ws) => {
+                    auth_failures = 0;
+                    backoff = INITIAL_BACKOFF;
+                    ws
+                }
+                Err(e @ HaError::AuthInvalid(_)) => {
+                    auth_failures += 1;
+                    let _ = out.send(HaEvent::Disconnected(e)).await;
+
+                    if auth_failures >= MAX_AUTH_FAILURES {
+                        let _ = out
+                            .send(HaEvent::AuthFailed(HaError::AuthExhausted {
+                                attempts: auth_failures,
+                            }))
+                            .await;
+                        return; // stream ended
+                    }
+                    sleep(AUTH_RETRY_DELAY).await;
+                    continue;
+                }
                 Err(e) => {
-                    let _ = output
-                        .send(HaEvent::Disconnected(format!("connect: {e}")))
-                        .await;
-                    sleep(connect_backoff).await;
-                    connect_backoff = (connect_backoff * 2).min(MAX_BACKOFF);
+                    let _ = out.send(HaEvent::Disconnected(e)).await;
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(MAX_BACKOFF);
                     continue;
                 }
             };
 
-            let (mut sink, mut stream) = ws.split();
+            // Autenticated + subscribed
+            let _ = out.send(HaEvent::Connected).await;
+            let initial = rest::fetch_all_states(&cfg.url, &cfg.token).await;
+            let _ = out.send(HaEvent::InitialState(initial)).await;
 
-            while let Some(msg) = stream.next().await {
-                let Ok(msg) = msg else { continue };
-                let Ok(text) = msg.to_text() else { continue };
-
-                if text.contains("\"auth_required\"") {
-                    break;
-                }
-            }
-
-            let auth = json!({"type": "auth", "access_token": token});
-
-            if sink
-                .send(WsMessage::Text(Utf8Bytes::from(auth.to_string())))
-                .await
-                .is_err()
-            {
-                let _ = output
-                    .send(HaEvent::Disconnected("auth send failed".into()))
-                    .await;
-                sleep(Duration::from_secs(2)).await;
-                continue;
-            }
-
-            let mut authed = false;
-
-            while let Some(msg) = stream.next().await {
-                let Ok(msg) = msg else { continue };
-                let Ok(text) = msg.to_text() else { continue };
-
-                if text.contains("\"auth_ok\"") {
-                    authed = true;
-                    auth_failures = 0;
-                    break;
-                }
-
-                if text.contains("\"auth_invalid\"") {
-                    auth_failures += 1;
-                    let _ = output
-                        .send(HaEvent::Disconnected(format!("auth_invalid (attempt {auth_failures}/{MAX_AUTH_FAILURES}")))
-                        .await;
-                    break;
-                }
-            }
-
-            if !authed {
-                sleep(Duration::from_secs(3)).await;
-                continue;
-            }
-
-            let sub = json!({
-                "id": 1,
-                "type": "subscribe_events",
-                "event_type": "state_changed"
-            });
-
-            if sink
-                .send(WsMessage::Text(Utf8Bytes::from(sub.to_string())))
-                .await
-                .is_err()
-            {
-                let _ = output
-                    .send(HaEvent::Disconnected("subscribe failed".into()))
-                    .await;
-                sleep(Duration::from_secs(2)).await;
-                continue;
-            }
-
-            let _ = output.send(HaEvent::Connected).await;
-            connect_backoff = Duration::from_secs(2);
-
-            let initial_states = rest::fetch_all_states(ha_url.clone(), token.clone()).await;
-            let _ = output.send(HaEvent::InitialState(initial_states)).await;
-
-            let mut heartbeat = interval(Duration::from_secs(30));
-            let mut last_received = Instant::now();
-
-            loop {
-                tokio::select! {
-                    msg = stream.next() => {
-                        let Some(msg) = msg else { break };
-                        let Ok(msg) = msg else { continue };
-
-                        last_received = Instant::now();
-
-                        let Ok(text) = msg.to_text() else { continue };
-
-                        if let Ok(parsed) = serde_json::from_str::<Incoming>(text)
-                        && parsed.r#type == "event"
-                        && let Some(ev) = parsed.event
-                        && ev.event_type == "state_changed"
-                        && let Some(data) = ev.data
-                        && let Some(new_state) = data.new_state
-                        {
-                            let _ = output.send(HaEvent::StateChanged { new_state}).await;
-                        }
-                    }
-                    _ = heartbeat.tick() => {
-                            if last_received.elapsed() > Duration::from_secs(90) {
-                                break;
-                            }
-                            if sink.send(WsMessage::Ping(vec![].into())).await.is_err()
-                            { break; }
-                        }
-                }
-            }
-
-            let _ = output.send(HaEvent::Disconnected("ws closed".into())).await;
-            sleep(Duration::from_secs(2)).await;
+            // run Forrest, run!
+            let reason = pump_events(&mut sink, &mut stream, &mut out).await;
+            let _ = out.send(HaEvent::Disconnected(reason)).await;
+            sleep(RECONNECT_DELAY).await;
         }
     })
     .boxed()
 }
+
+// TESTS
+
+#[cfg(test)]
+mod tests;

--- a/src/ha/ws/tests.rs
+++ b/src/ha/ws/tests.rs
@@ -1,0 +1,406 @@
+ use super::*;
+
+ // ================================================================
+ // ws_url_from_http — HTTP(s) → WS(s) URL rewriting
+ // ================================================================
+ mod url_conversion {
+     use super::*;
+
+     #[test]
+     fn https_becomes_wss() {
+         let u = ws_url_from_http("https://ha.local/").unwrap();
+         assert_eq!(u.as_str(), "wss://ha.local/api/websocket");
+     }
+
+     #[test]
+     fn http_becomes_ws() {
+         let u = ws_url_from_http("http://ha.local/").unwrap();
+         assert_eq!(u.as_str(), "ws://ha.local/api/websocket");
+     }
+
+     #[test]
+     fn preserves_port() {
+         let u = ws_url_from_http("http://ha.local:8123/").unwrap();
+         assert_eq!(u.as_str(), "ws://ha.local:8123/api/websocket");
+     }
+
+     #[test]
+     fn preserves_ipv4_host() {
+         let u = ws_url_from_http("http://192.168.1.10:8123/").unwrap();
+         assert_eq!(u.as_str(), "ws://192.168.1.10:8123/api/websocket");
+     }
+
+     #[test]
+     fn preserves_ipv6_host() {
+         let u = ws_url_from_http("http://[::1]:8123/").unwrap();
+         assert_eq!(u.as_str(), "ws://[::1]:8123/api/websocket");
+     }
+
+     #[test]
+     fn preserves_subpath_with_trailing_slash() {
+         // HA za reverse proxy na /ha/
+         let u = ws_url_from_http("https://ha.local/ha/").unwrap();
+         assert_eq!(u.as_str(), "wss://ha.local/ha/api/websocket");
+     }
+
+     #[test]
+     fn preserves_subpath_without_trailing_slash() {
+         let u = ws_url_from_http("https://ha.local/ha").unwrap();
+         assert_eq!(u.as_str(), "wss://ha.local/ha/api/websocket");
+     }
+
+     #[test]
+     fn preserves_deep_subpath() {
+         let u = ws_url_from_http("https://proxy.example.com/services/ha/").unwrap();
+         assert_eq!(
+             u.as_str(),
+             "wss://proxy.example.com/services/ha/api/websocket"
+         );
+     }
+
+     #[test]
+     fn no_path_component_works() {
+         let u = ws_url_from_http("https://ha.local").unwrap();
+         assert_eq!(u.as_str(), "wss://ha.local/api/websocket");
+     }
+
+     #[test]
+     fn lowercases_scheme() {
+         // RFC 3986: schémata case-insensitive; url crate normalizuje
+         let u = ws_url_from_http("HTTPS://ha.local/").unwrap();
+         assert_eq!(u.as_str(), "wss://ha.local/api/websocket");
+     }
+
+     #[test]
+     fn collapses_redundant_trailing_slashes() {
+         // guard proti "//api/websocket" bugu
+         let u = ws_url_from_http("https://ha.local///").unwrap();
+         assert!(!u.path().contains("//"));
+         assert!(u.path().ends_with("/api/websocket"));
+     }
+
+     #[test]
+     fn preserves_userinfo() {
+         let u = ws_url_from_http("https://user:pass@ha.local/").unwrap();
+         assert!(u.as_str().contains("user:pass@"));
+         assert!(u.as_str().ends_with("/api/websocket"));
+     }
+
+     #[test]
+     fn preserves_query_string() {
+         let u = ws_url_from_http("https://ha.local/?foo=bar").unwrap();
+         assert_eq!(u.query(), Some("foo=bar"));
+     }
+
+     #[test]
+     fn rejects_ftp_scheme() {
+         let err = ws_url_from_http("ftp://ha.local/").unwrap_err();
+         assert!(matches!(err, HaError::Protocol(_)));
+     }
+
+     #[test]
+     fn rejects_preconverted_ws_scheme() {
+         // API kontrakt: vstup je http(s), ne ws(s)
+         let err = ws_url_from_http("wss://ha.local/").unwrap_err();
+         assert!(matches!(err, HaError::Protocol(_)));
+     }
+
+     #[test]
+     fn rejects_missing_scheme() {
+         let err = ws_url_from_http("ha.local:8123").unwrap_err();
+         assert!(matches!(err, HaError::Protocol(_)));
+     }
+
+     #[test]
+     fn rejects_empty_string() {
+         assert!(matches!(
+             ws_url_from_http("").unwrap_err(),
+             HaError::Protocol(_)
+         ));
+     }
+
+     #[test]
+     fn rejects_garbage_input() {
+         assert!(matches!(
+             ws_url_from_http("not a url at all").unwrap_err(),
+             HaError::Protocol(_)
+         ));
+     }
+
+     #[test]
+     fn error_message_is_descriptive() {
+         // UX detail: uživatel uvidí v UI status baru → stojí za to
+         let err = ws_url_from_http("ftp://ha/").unwrap_err();
+         let HaError::Protocol(msg) = err else {
+             panic!()
+         };
+         assert!(
+             msg.contains("scheme"),
+             "expected 'scheme' in error message, got: {msg}"
+         );
+     }
+
+     #[test]
+     fn collapses_leading_double_slash_in_path() {
+         // uživatel zkopíroval URL z dokumentace kde bylo //
+         let u = ws_url_from_http("https://ha.local//ha/").unwrap();
+         assert_eq!(u.as_str(), "wss://ha.local/ha/api/websocket");
+     }
+
+     #[test]
+     fn handles_only_path_with_slashes() {
+         let u = ws_url_from_http("https://ha.local////").unwrap();
+         assert_eq!(u.as_str(), "wss://ha.local/api/websocket");
+     }
+
+     #[test]
+     fn preserves_middle_double_slash_if_user_really_put_it_there() {
+         // middle // je v URL spec validní; my ho nemažeme (je to možná záměr)
+         let u = ws_url_from_http("https://ha.local/a//b/").unwrap();
+         assert_eq!(u.as_str(), "wss://ha.local/a//b/api/websocket");
+     }
+ }
+
+ // ================================================================
+ // ServerMsg — deserializace příchozích zpráv z HA
+ // ================================================================
+ mod server_msg_decode {
+     use super::*;
+
+     #[test]
+     fn auth_required_with_version() {
+         let msg: ServerMsg =
+             serde_json::from_str(r#"{"type":"auth_required","ha_version":"2024.5.0"}"#)
+                 .unwrap();
+         assert!(matches!(msg, ServerMsg::AuthRequired { .. }));
+     }
+
+     #[test]
+     fn auth_required_without_version() {
+         let msg: ServerMsg = serde_json::from_str(r#"{"type":"auth_required"}"#).unwrap();
+         assert!(matches!(msg, ServerMsg::AuthRequired { .. }));
+     }
+
+     #[test]
+     fn auth_ok_decodes() {
+         let msg: ServerMsg =
+             serde_json::from_str(r#"{"type":"auth_ok","ha_version":"2024.5"}"#).unwrap();
+         assert!(matches!(msg, ServerMsg::AuthOk { .. }));
+     }
+
+     #[test]
+     fn auth_invalid_carries_message() {
+         let msg: ServerMsg =
+             serde_json::from_str(r#"{"type":"auth_invalid","message":"Invalid access token"}"#)
+                 .unwrap();
+         let ServerMsg::AuthInvalid { message } = msg else {
+             panic!("expected AuthInvalid, got {msg:?}");
+         };
+         assert_eq!(message, "Invalid access token");
+     }
+
+     #[test]
+     fn auth_invalid_defaults_empty_message() {
+         let msg: ServerMsg = serde_json::from_str(r#"{"type":"auth_invalid"}"#).unwrap();
+         let ServerMsg::AuthInvalid { message } = msg else {
+             panic!()
+         };
+         assert!(message.is_empty());
+     }
+
+     #[test]
+     fn state_changed_event_full_payload() {
+         let raw = r#"{
+             "type":"event",
+             "id":1,
+             "event":{
+                 "event_type":"state_changed",
+                 "data":{
+                     "new_state":{
+                         "entity_id":"light.kitchen",
+                         "state":"on",
+                         "attributes":{"brightness":255}
+                     }
+                 }
+             }
+         }"#;
+         let msg: ServerMsg = serde_json::from_str(raw).unwrap();
+         let ServerMsg::Event { event, .. } = msg else {
+             panic!("expected Event, got {msg:?}")
+         };
+         assert_eq!(event.event_type, "state_changed");
+         let new_state = event.data.new_state.expect("new_state present");
+         assert_eq!(new_state.entity_id, "light.kitchen");
+         assert_eq!(new_state.state, "on");
+     }
+
+     #[test]
+     fn event_without_new_state_is_ok() {
+         // typicky u service_called, call_service ack, atd.
+         let raw = r#"{"type":"event","event":{"event_type":"service_called","data":{}}}"#;
+         let msg: ServerMsg = serde_json::from_str(raw).unwrap();
+         let ServerMsg::Event { event, .. } = msg else {
+             panic!()
+         };
+         assert!(event.data.new_state.is_none());
+     }
+
+     #[test]
+     fn event_without_data_field_is_ok() {
+         let raw = r#"{"type":"event","event":{"event_type":"whatever"}}"#;
+         let msg: ServerMsg = serde_json::from_str(raw).unwrap();
+         assert!(matches!(msg, ServerMsg::Event { .. }));
+     }
+
+     #[test]
+     fn event_without_id_is_ok() {
+         // některé HA eventy chodí bez id
+         let raw = r#"{"type":"event","event":{"event_type":"state_changed","data":{}}}"#;
+         let msg: ServerMsg = serde_json::from_str(raw).unwrap();
+         assert!(matches!(msg, ServerMsg::Event { id: None, .. }));
+     }
+
+     #[test]
+     fn result_success_decodes() {
+         let msg: ServerMsg =
+             serde_json::from_str(r#"{"type":"result","id":1,"success":true}"#).unwrap();
+         assert!(matches!(msg, ServerMsg::Result { success: true, .. }));
+     }
+
+     #[test]
+     fn result_with_error_payload() {
+         let raw = r#"{"type":"result","id":2,"success":false,"error":{"code":"not_found"}}"#;
+         let msg: ServerMsg = serde_json::from_str(raw).unwrap();
+         assert!(matches!(
+             msg,
+             ServerMsg::Result {
+                 success: false,
+                 error: Some(_),
+                 ..
+             }
+         ));
+     }
+
+     #[test]
+     fn pong_decodes() {
+         let msg: ServerMsg = serde_json::from_str(r#"{"type":"pong","id":5}"#).unwrap();
+         assert!(matches!(msg, ServerMsg::Pong { .. }));
+     }
+
+     #[test]
+     fn unknown_type_falls_to_other() {
+         // forward-compat: HA někdy přidá nový type — klient nesmí spadnout
+         let msg: ServerMsg =
+             serde_json::from_str(r#"{"type":"future_thing","whatever":42}"#).unwrap();
+         assert!(matches!(msg, ServerMsg::Other));
+     }
+
+     #[test]
+     fn extra_fields_are_ignored() {
+         // HA přidá nové pole do existujícího type → zpracujeme dál
+         let raw = r#"{"type":"auth_ok","ha_version":"2024","__new_field__":"x"}"#;
+         assert!(matches!(
+             serde_json::from_str::<ServerMsg>(raw).unwrap(),
+             ServerMsg::AuthOk { .. }
+         ));
+     }
+
+     #[test]
+     fn missing_type_is_error() {
+         // bez type tagu serde neví, kterou variantu vybrat
+         assert!(serde_json::from_str::<ServerMsg>(r#"{"some":"thing"}"#).is_err());
+     }
+
+     #[test]
+     fn malformed_json_is_error() {
+         assert!(serde_json::from_str::<ServerMsg>("not json").is_err());
+     }
+
+     #[test]
+     fn empty_object_is_error() {
+         assert!(serde_json::from_str::<ServerMsg>("{}").is_err());
+     }
+ }
+
+ // ================================================================
+ // ClientMsg — serializace odchozích zpráv na HA
+ // ================================================================
+ mod client_msg_encode {
+     use super::*;
+
+     #[test]
+     fn auth_msg_has_correct_wire_format() {
+         let msg = ClientMsg::Auth {
+             access_token: "secret",
+         };
+         let v: serde_json::Value =
+             serde_json::from_str(&serde_json::to_string(&msg).unwrap()).unwrap();
+         assert_eq!(v["type"], "auth");
+         assert_eq!(v["access_token"], "secret");
+     }
+
+     #[test]
+     fn subscribe_events_has_correct_wire_format() {
+         let msg = ClientMsg::SubscribeEvents {
+             id: 1,
+             event_type: "state_changed",
+         };
+         let v: serde_json::Value =
+             serde_json::from_str(&serde_json::to_string(&msg).unwrap()).unwrap();
+         assert_eq!(v["type"], "subscribe_events");
+         assert_eq!(v["id"], 1);
+         assert_eq!(v["event_type"], "state_changed");
+     }
+
+     #[test]
+     fn token_with_special_chars_survives_roundtrip() {
+         let msg = ClientMsg::Auth {
+             access_token: "ab\"c\ne\\f",
+         };
+         let json = serde_json::to_string(&msg).unwrap();
+         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+         assert_eq!(v["access_token"], "ab\"c\ne\\f");
+     }
+
+     #[test]
+     fn unicode_in_token_survives_roundtrip() {
+         let msg = ClientMsg::Auth {
+             access_token: "č🦀ü",
+         };
+         let json = serde_json::to_string(&msg).unwrap();
+         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+         assert_eq!(v["access_token"], "č🦀ü");
+     }
+ }
+
+ // ================================================================
+ // Sanity checks pro konstanty — zachytí bugy typu "překlep v čísle"
+ // ================================================================
+ mod constants {
+     use super::*;
+
+     #[test]
+     fn backoff_bounds_are_sane() {
+         assert!(INITIAL_BACKOFF <= MAX_BACKOFF);
+         assert!(INITIAL_BACKOFF > Duration::ZERO);
+     }
+
+     #[test]
+     fn heartbeat_fires_before_stale_threshold() {
+         // musíme pingnout aspoň jednou před tím, než bychom prohlásili stale
+         // jinak by se spojení ukončilo dřív, než by vůbec mělo šanci
+         assert!(HEARTBEAT_INTERVAL < STALE_AFTER);
+     }
+
+     #[test]
+     fn auth_failures_bound_is_positive() {
+         // 0 by znamenalo "okamžitě vzdej", nemá smysl
+         assert!(MAX_AUTH_FAILURES > 0);
+     }
+
+     #[test]
+     fn event_channel_has_capacity() {
+         assert!(EVENT_CHANNEL_CAPACITY > 0);
+     }
+ }
+

--- a/src/ha/ws/tests.rs
+++ b/src/ha/ws/tests.rs
@@ -1,216 +1,215 @@
- use super::*;
+use super::*;
 
- // ================================================================
- // ws_url_from_http — HTTP(s) → WS(s) URL rewriting
- // ================================================================
- mod url_conversion {
-     use super::*;
+// ================================================================
+// ws_url_from_http — HTTP(s) → WS(s) URL rewriting
+// ================================================================
+mod url_conversion {
+    use super::*;
 
-     #[test]
-     fn https_becomes_wss() {
-         let u = ws_url_from_http("https://ha.local/").unwrap();
-         assert_eq!(u.as_str(), "wss://ha.local/api/websocket");
-     }
+    #[test]
+    fn https_becomes_wss() {
+        let u = ws_url_from_http("https://ha.local/").unwrap();
+        assert_eq!(u.as_str(), "wss://ha.local/api/websocket");
+    }
 
-     #[test]
-     fn http_becomes_ws() {
-         let u = ws_url_from_http("http://ha.local/").unwrap();
-         assert_eq!(u.as_str(), "ws://ha.local/api/websocket");
-     }
+    #[test]
+    fn http_becomes_ws() {
+        let u = ws_url_from_http("http://ha.local/").unwrap();
+        assert_eq!(u.as_str(), "ws://ha.local/api/websocket");
+    }
 
-     #[test]
-     fn preserves_port() {
-         let u = ws_url_from_http("http://ha.local:8123/").unwrap();
-         assert_eq!(u.as_str(), "ws://ha.local:8123/api/websocket");
-     }
+    #[test]
+    fn preserves_port() {
+        let u = ws_url_from_http("http://ha.local:8123/").unwrap();
+        assert_eq!(u.as_str(), "ws://ha.local:8123/api/websocket");
+    }
 
-     #[test]
-     fn preserves_ipv4_host() {
-         let u = ws_url_from_http("http://192.168.1.10:8123/").unwrap();
-         assert_eq!(u.as_str(), "ws://192.168.1.10:8123/api/websocket");
-     }
+    #[test]
+    fn preserves_ipv4_host() {
+        let u = ws_url_from_http("http://192.168.1.10:8123/").unwrap();
+        assert_eq!(u.as_str(), "ws://192.168.1.10:8123/api/websocket");
+    }
 
-     #[test]
-     fn preserves_ipv6_host() {
-         let u = ws_url_from_http("http://[::1]:8123/").unwrap();
-         assert_eq!(u.as_str(), "ws://[::1]:8123/api/websocket");
-     }
+    #[test]
+    fn preserves_ipv6_host() {
+        let u = ws_url_from_http("http://[::1]:8123/").unwrap();
+        assert_eq!(u.as_str(), "ws://[::1]:8123/api/websocket");
+    }
 
-     #[test]
-     fn preserves_subpath_with_trailing_slash() {
-         // HA za reverse proxy na /ha/
-         let u = ws_url_from_http("https://ha.local/ha/").unwrap();
-         assert_eq!(u.as_str(), "wss://ha.local/ha/api/websocket");
-     }
+    #[test]
+    fn preserves_subpath_with_trailing_slash() {
+        // HA za reverse proxy na /ha/
+        let u = ws_url_from_http("https://ha.local/ha/").unwrap();
+        assert_eq!(u.as_str(), "wss://ha.local/ha/api/websocket");
+    }
 
-     #[test]
-     fn preserves_subpath_without_trailing_slash() {
-         let u = ws_url_from_http("https://ha.local/ha").unwrap();
-         assert_eq!(u.as_str(), "wss://ha.local/ha/api/websocket");
-     }
+    #[test]
+    fn preserves_subpath_without_trailing_slash() {
+        let u = ws_url_from_http("https://ha.local/ha").unwrap();
+        assert_eq!(u.as_str(), "wss://ha.local/ha/api/websocket");
+    }
 
-     #[test]
-     fn preserves_deep_subpath() {
-         let u = ws_url_from_http("https://proxy.example.com/services/ha/").unwrap();
-         assert_eq!(
-             u.as_str(),
-             "wss://proxy.example.com/services/ha/api/websocket"
-         );
-     }
+    #[test]
+    fn preserves_deep_subpath() {
+        let u = ws_url_from_http("https://proxy.example.com/services/ha/").unwrap();
+        assert_eq!(
+            u.as_str(),
+            "wss://proxy.example.com/services/ha/api/websocket"
+        );
+    }
 
-     #[test]
-     fn no_path_component_works() {
-         let u = ws_url_from_http("https://ha.local").unwrap();
-         assert_eq!(u.as_str(), "wss://ha.local/api/websocket");
-     }
+    #[test]
+    fn no_path_component_works() {
+        let u = ws_url_from_http("https://ha.local").unwrap();
+        assert_eq!(u.as_str(), "wss://ha.local/api/websocket");
+    }
 
-     #[test]
-     fn lowercases_scheme() {
-         // RFC 3986: schémata case-insensitive; url crate normalizuje
-         let u = ws_url_from_http("HTTPS://ha.local/").unwrap();
-         assert_eq!(u.as_str(), "wss://ha.local/api/websocket");
-     }
+    #[test]
+    fn lowercases_scheme() {
+        // RFC 3986: schémata case-insensitive; url crate normalizuje
+        let u = ws_url_from_http("HTTPS://ha.local/").unwrap();
+        assert_eq!(u.as_str(), "wss://ha.local/api/websocket");
+    }
 
-     #[test]
-     fn collapses_redundant_trailing_slashes() {
-         // guard proti "//api/websocket" bugu
-         let u = ws_url_from_http("https://ha.local///").unwrap();
-         assert!(!u.path().contains("//"));
-         assert!(u.path().ends_with("/api/websocket"));
-     }
+    #[test]
+    fn collapses_redundant_trailing_slashes() {
+        // guard proti "//api/websocket" bugu
+        let u = ws_url_from_http("https://ha.local///").unwrap();
+        assert!(!u.path().contains("//"));
+        assert!(u.path().ends_with("/api/websocket"));
+    }
 
-     #[test]
-     fn preserves_userinfo() {
-         let u = ws_url_from_http("https://user:pass@ha.local/").unwrap();
-         assert!(u.as_str().contains("user:pass@"));
-         assert!(u.as_str().ends_with("/api/websocket"));
-     }
+    #[test]
+    fn preserves_userinfo() {
+        let u = ws_url_from_http("https://user:pass@ha.local/").unwrap();
+        assert!(u.as_str().contains("user:pass@"));
+        assert!(u.as_str().ends_with("/api/websocket"));
+    }
 
-     #[test]
-     fn preserves_query_string() {
-         let u = ws_url_from_http("https://ha.local/?foo=bar").unwrap();
-         assert_eq!(u.query(), Some("foo=bar"));
-     }
+    #[test]
+    fn preserves_query_string() {
+        let u = ws_url_from_http("https://ha.local/?foo=bar").unwrap();
+        assert_eq!(u.query(), Some("foo=bar"));
+    }
 
-     #[test]
-     fn rejects_ftp_scheme() {
-         let err = ws_url_from_http("ftp://ha.local/").unwrap_err();
-         assert!(matches!(err, HaError::Protocol(_)));
-     }
+    #[test]
+    fn rejects_ftp_scheme() {
+        let err = ws_url_from_http("ftp://ha.local/").unwrap_err();
+        assert!(matches!(err, HaError::Protocol(_)));
+    }
 
-     #[test]
-     fn rejects_preconverted_ws_scheme() {
-         // API kontrakt: vstup je http(s), ne ws(s)
-         let err = ws_url_from_http("wss://ha.local/").unwrap_err();
-         assert!(matches!(err, HaError::Protocol(_)));
-     }
+    #[test]
+    fn rejects_preconverted_ws_scheme() {
+        // API kontrakt: vstup je http(s), ne ws(s)
+        let err = ws_url_from_http("wss://ha.local/").unwrap_err();
+        assert!(matches!(err, HaError::Protocol(_)));
+    }
 
-     #[test]
-     fn rejects_missing_scheme() {
-         let err = ws_url_from_http("ha.local:8123").unwrap_err();
-         assert!(matches!(err, HaError::Protocol(_)));
-     }
+    #[test]
+    fn rejects_missing_scheme() {
+        let err = ws_url_from_http("ha.local:8123").unwrap_err();
+        assert!(matches!(err, HaError::Protocol(_)));
+    }
 
-     #[test]
-     fn rejects_empty_string() {
-         assert!(matches!(
-             ws_url_from_http("").unwrap_err(),
-             HaError::Protocol(_)
-         ));
-     }
+    #[test]
+    fn rejects_empty_string() {
+        assert!(matches!(
+            ws_url_from_http("").unwrap_err(),
+            HaError::Protocol(_)
+        ));
+    }
 
-     #[test]
-     fn rejects_garbage_input() {
-         assert!(matches!(
-             ws_url_from_http("not a url at all").unwrap_err(),
-             HaError::Protocol(_)
-         ));
-     }
+    #[test]
+    fn rejects_garbage_input() {
+        assert!(matches!(
+            ws_url_from_http("not a url at all").unwrap_err(),
+            HaError::Protocol(_)
+        ));
+    }
 
-     #[test]
-     fn error_message_is_descriptive() {
-         // UX detail: uživatel uvidí v UI status baru → stojí za to
-         let err = ws_url_from_http("ftp://ha/").unwrap_err();
-         let HaError::Protocol(msg) = err else {
-             panic!()
-         };
-         assert!(
-             msg.contains("scheme"),
-             "expected 'scheme' in error message, got: {msg}"
-         );
-     }
+    #[test]
+    fn error_message_is_descriptive() {
+        // UX detail: uživatel uvidí v UI status baru → stojí za to
+        let err = ws_url_from_http("ftp://ha/").unwrap_err();
+        let HaError::Protocol(msg) = err else {
+            panic!()
+        };
+        assert!(
+            msg.contains("scheme"),
+            "expected 'scheme' in error message, got: {msg}"
+        );
+    }
 
-     #[test]
-     fn collapses_leading_double_slash_in_path() {
-         // uživatel zkopíroval URL z dokumentace kde bylo //
-         let u = ws_url_from_http("https://ha.local//ha/").unwrap();
-         assert_eq!(u.as_str(), "wss://ha.local/ha/api/websocket");
-     }
+    #[test]
+    fn collapses_leading_double_slash_in_path() {
+        // uživatel zkopíroval URL z dokumentace kde bylo //
+        let u = ws_url_from_http("https://ha.local//ha/").unwrap();
+        assert_eq!(u.as_str(), "wss://ha.local/ha/api/websocket");
+    }
 
-     #[test]
-     fn handles_only_path_with_slashes() {
-         let u = ws_url_from_http("https://ha.local////").unwrap();
-         assert_eq!(u.as_str(), "wss://ha.local/api/websocket");
-     }
+    #[test]
+    fn handles_only_path_with_slashes() {
+        let u = ws_url_from_http("https://ha.local////").unwrap();
+        assert_eq!(u.as_str(), "wss://ha.local/api/websocket");
+    }
 
-     #[test]
-     fn preserves_middle_double_slash_if_user_really_put_it_there() {
-         // middle // je v URL spec validní; my ho nemažeme (je to možná záměr)
-         let u = ws_url_from_http("https://ha.local/a//b/").unwrap();
-         assert_eq!(u.as_str(), "wss://ha.local/a//b/api/websocket");
-     }
- }
+    #[test]
+    fn preserves_middle_double_slash_if_user_really_put_it_there() {
+        // middle // je v URL spec validní; my ho nemažeme (je to možná záměr)
+        let u = ws_url_from_http("https://ha.local/a//b/").unwrap();
+        assert_eq!(u.as_str(), "wss://ha.local/a//b/api/websocket");
+    }
+}
 
- // ================================================================
- // ServerMsg — deserializace příchozích zpráv z HA
- // ================================================================
- mod server_msg_decode {
-     use super::*;
+// ================================================================
+// ServerMsg — deserializace příchozích zpráv z HA
+// ================================================================
+mod server_msg_decode {
+    use super::*;
 
-     #[test]
-     fn auth_required_with_version() {
-         let msg: ServerMsg =
-             serde_json::from_str(r#"{"type":"auth_required","ha_version":"2024.5.0"}"#)
-                 .unwrap();
-         assert!(matches!(msg, ServerMsg::AuthRequired { .. }));
-     }
+    #[test]
+    fn auth_required_with_version() {
+        let msg: ServerMsg =
+            serde_json::from_str(r#"{"type":"auth_required","ha_version":"2024.5.0"}"#).unwrap();
+        assert!(matches!(msg, ServerMsg::AuthRequired { .. }));
+    }
 
-     #[test]
-     fn auth_required_without_version() {
-         let msg: ServerMsg = serde_json::from_str(r#"{"type":"auth_required"}"#).unwrap();
-         assert!(matches!(msg, ServerMsg::AuthRequired { .. }));
-     }
+    #[test]
+    fn auth_required_without_version() {
+        let msg: ServerMsg = serde_json::from_str(r#"{"type":"auth_required"}"#).unwrap();
+        assert!(matches!(msg, ServerMsg::AuthRequired { .. }));
+    }
 
-     #[test]
-     fn auth_ok_decodes() {
-         let msg: ServerMsg =
-             serde_json::from_str(r#"{"type":"auth_ok","ha_version":"2024.5"}"#).unwrap();
-         assert!(matches!(msg, ServerMsg::AuthOk { .. }));
-     }
+    #[test]
+    fn auth_ok_decodes() {
+        let msg: ServerMsg =
+            serde_json::from_str(r#"{"type":"auth_ok","ha_version":"2024.5"}"#).unwrap();
+        assert!(matches!(msg, ServerMsg::AuthOk { .. }));
+    }
 
-     #[test]
-     fn auth_invalid_carries_message() {
-         let msg: ServerMsg =
-             serde_json::from_str(r#"{"type":"auth_invalid","message":"Invalid access token"}"#)
-                 .unwrap();
-         let ServerMsg::AuthInvalid { message } = msg else {
-             panic!("expected AuthInvalid, got {msg:?}");
-         };
-         assert_eq!(message, "Invalid access token");
-     }
+    #[test]
+    fn auth_invalid_carries_message() {
+        let msg: ServerMsg =
+            serde_json::from_str(r#"{"type":"auth_invalid","message":"Invalid access token"}"#)
+                .unwrap();
+        let ServerMsg::AuthInvalid { message } = msg else {
+            panic!("expected AuthInvalid, got {msg:?}");
+        };
+        assert_eq!(message, "Invalid access token");
+    }
 
-     #[test]
-     fn auth_invalid_defaults_empty_message() {
-         let msg: ServerMsg = serde_json::from_str(r#"{"type":"auth_invalid"}"#).unwrap();
-         let ServerMsg::AuthInvalid { message } = msg else {
-             panic!()
-         };
-         assert!(message.is_empty());
-     }
+    #[test]
+    fn auth_invalid_defaults_empty_message() {
+        let msg: ServerMsg = serde_json::from_str(r#"{"type":"auth_invalid"}"#).unwrap();
+        let ServerMsg::AuthInvalid { message } = msg else {
+            panic!()
+        };
+        assert!(message.is_empty());
+    }
 
-     #[test]
-     fn state_changed_event_full_payload() {
-         let raw = r#"{
+    #[test]
+    fn state_changed_event_full_payload() {
+        let raw = r#"{
              "type":"event",
              "id":1,
              "event":{
@@ -224,183 +223,182 @@
                  }
              }
          }"#;
-         let msg: ServerMsg = serde_json::from_str(raw).unwrap();
-         let ServerMsg::Event { event, .. } = msg else {
-             panic!("expected Event, got {msg:?}")
-         };
-         assert_eq!(event.event_type, "state_changed");
-         let new_state = event.data.new_state.expect("new_state present");
-         assert_eq!(new_state.entity_id, "light.kitchen");
-         assert_eq!(new_state.state, "on");
-     }
+        let msg: ServerMsg = serde_json::from_str(raw).unwrap();
+        let ServerMsg::Event { event, .. } = msg else {
+            panic!("expected Event, got {msg:?}")
+        };
+        assert_eq!(event.event_type, "state_changed");
+        let new_state = event.data.new_state.expect("new_state present");
+        assert_eq!(new_state.entity_id, "light.kitchen");
+        assert_eq!(new_state.state, "on");
+    }
 
-     #[test]
-     fn event_without_new_state_is_ok() {
-         // typicky u service_called, call_service ack, atd.
-         let raw = r#"{"type":"event","event":{"event_type":"service_called","data":{}}}"#;
-         let msg: ServerMsg = serde_json::from_str(raw).unwrap();
-         let ServerMsg::Event { event, .. } = msg else {
-             panic!()
-         };
-         assert!(event.data.new_state.is_none());
-     }
+    #[test]
+    fn event_without_new_state_is_ok() {
+        // typicky u service_called, call_service ack, atd.
+        let raw = r#"{"type":"event","event":{"event_type":"service_called","data":{}}}"#;
+        let msg: ServerMsg = serde_json::from_str(raw).unwrap();
+        let ServerMsg::Event { event, .. } = msg else {
+            panic!()
+        };
+        assert!(event.data.new_state.is_none());
+    }
 
-     #[test]
-     fn event_without_data_field_is_ok() {
-         let raw = r#"{"type":"event","event":{"event_type":"whatever"}}"#;
-         let msg: ServerMsg = serde_json::from_str(raw).unwrap();
-         assert!(matches!(msg, ServerMsg::Event { .. }));
-     }
+    #[test]
+    fn event_without_data_field_is_ok() {
+        let raw = r#"{"type":"event","event":{"event_type":"whatever"}}"#;
+        let msg: ServerMsg = serde_json::from_str(raw).unwrap();
+        assert!(matches!(msg, ServerMsg::Event { .. }));
+    }
 
-     #[test]
-     fn event_without_id_is_ok() {
-         // některé HA eventy chodí bez id
-         let raw = r#"{"type":"event","event":{"event_type":"state_changed","data":{}}}"#;
-         let msg: ServerMsg = serde_json::from_str(raw).unwrap();
-         assert!(matches!(msg, ServerMsg::Event { id: None, .. }));
-     }
+    #[test]
+    fn event_without_id_is_ok() {
+        // některé HA eventy chodí bez id
+        let raw = r#"{"type":"event","event":{"event_type":"state_changed","data":{}}}"#;
+        let msg: ServerMsg = serde_json::from_str(raw).unwrap();
+        assert!(matches!(msg, ServerMsg::Event { id: None, .. }));
+    }
 
-     #[test]
-     fn result_success_decodes() {
-         let msg: ServerMsg =
-             serde_json::from_str(r#"{"type":"result","id":1,"success":true}"#).unwrap();
-         assert!(matches!(msg, ServerMsg::Result { success: true, .. }));
-     }
+    #[test]
+    fn result_success_decodes() {
+        let msg: ServerMsg =
+            serde_json::from_str(r#"{"type":"result","id":1,"success":true}"#).unwrap();
+        assert!(matches!(msg, ServerMsg::Result { success: true, .. }));
+    }
 
-     #[test]
-     fn result_with_error_payload() {
-         let raw = r#"{"type":"result","id":2,"success":false,"error":{"code":"not_found"}}"#;
-         let msg: ServerMsg = serde_json::from_str(raw).unwrap();
-         assert!(matches!(
-             msg,
-             ServerMsg::Result {
-                 success: false,
-                 error: Some(_),
-                 ..
-             }
-         ));
-     }
+    #[test]
+    fn result_with_error_payload() {
+        let raw = r#"{"type":"result","id":2,"success":false,"error":{"code":"not_found"}}"#;
+        let msg: ServerMsg = serde_json::from_str(raw).unwrap();
+        assert!(matches!(
+            msg,
+            ServerMsg::Result {
+                success: false,
+                error: Some(_),
+                ..
+            }
+        ));
+    }
 
-     #[test]
-     fn pong_decodes() {
-         let msg: ServerMsg = serde_json::from_str(r#"{"type":"pong","id":5}"#).unwrap();
-         assert!(matches!(msg, ServerMsg::Pong { .. }));
-     }
+    #[test]
+    fn pong_decodes() {
+        let msg: ServerMsg = serde_json::from_str(r#"{"type":"pong","id":5}"#).unwrap();
+        assert!(matches!(msg, ServerMsg::Pong { .. }));
+    }
 
-     #[test]
-     fn unknown_type_falls_to_other() {
-         // forward-compat: HA někdy přidá nový type — klient nesmí spadnout
-         let msg: ServerMsg =
-             serde_json::from_str(r#"{"type":"future_thing","whatever":42}"#).unwrap();
-         assert!(matches!(msg, ServerMsg::Other));
-     }
+    #[test]
+    fn unknown_type_falls_to_other() {
+        // forward-compat: HA někdy přidá nový type — klient nesmí spadnout
+        let msg: ServerMsg =
+            serde_json::from_str(r#"{"type":"future_thing","whatever":42}"#).unwrap();
+        assert!(matches!(msg, ServerMsg::Other));
+    }
 
-     #[test]
-     fn extra_fields_are_ignored() {
-         // HA přidá nové pole do existujícího type → zpracujeme dál
-         let raw = r#"{"type":"auth_ok","ha_version":"2024","__new_field__":"x"}"#;
-         assert!(matches!(
-             serde_json::from_str::<ServerMsg>(raw).unwrap(),
-             ServerMsg::AuthOk { .. }
-         ));
-     }
+    #[test]
+    fn extra_fields_are_ignored() {
+        // HA přidá nové pole do existujícího type → zpracujeme dál
+        let raw = r#"{"type":"auth_ok","ha_version":"2024","__new_field__":"x"}"#;
+        assert!(matches!(
+            serde_json::from_str::<ServerMsg>(raw).unwrap(),
+            ServerMsg::AuthOk { .. }
+        ));
+    }
 
-     #[test]
-     fn missing_type_is_error() {
-         // bez type tagu serde neví, kterou variantu vybrat
-         assert!(serde_json::from_str::<ServerMsg>(r#"{"some":"thing"}"#).is_err());
-     }
+    #[test]
+    fn missing_type_is_error() {
+        // bez type tagu serde neví, kterou variantu vybrat
+        assert!(serde_json::from_str::<ServerMsg>(r#"{"some":"thing"}"#).is_err());
+    }
 
-     #[test]
-     fn malformed_json_is_error() {
-         assert!(serde_json::from_str::<ServerMsg>("not json").is_err());
-     }
+    #[test]
+    fn malformed_json_is_error() {
+        assert!(serde_json::from_str::<ServerMsg>("not json").is_err());
+    }
 
-     #[test]
-     fn empty_object_is_error() {
-         assert!(serde_json::from_str::<ServerMsg>("{}").is_err());
-     }
- }
+    #[test]
+    fn empty_object_is_error() {
+        assert!(serde_json::from_str::<ServerMsg>("{}").is_err());
+    }
+}
 
- // ================================================================
- // ClientMsg — serializace odchozích zpráv na HA
- // ================================================================
- mod client_msg_encode {
-     use super::*;
+// ================================================================
+// ClientMsg — serializace odchozích zpráv na HA
+// ================================================================
+mod client_msg_encode {
+    use super::*;
 
-     #[test]
-     fn auth_msg_has_correct_wire_format() {
-         let msg = ClientMsg::Auth {
-             access_token: "secret",
-         };
-         let v: serde_json::Value =
-             serde_json::from_str(&serde_json::to_string(&msg).unwrap()).unwrap();
-         assert_eq!(v["type"], "auth");
-         assert_eq!(v["access_token"], "secret");
-     }
+    #[test]
+    fn auth_msg_has_correct_wire_format() {
+        let msg = ClientMsg::Auth {
+            access_token: "secret",
+        };
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&msg).unwrap()).unwrap();
+        assert_eq!(v["type"], "auth");
+        assert_eq!(v["access_token"], "secret");
+    }
 
-     #[test]
-     fn subscribe_events_has_correct_wire_format() {
-         let msg = ClientMsg::SubscribeEvents {
-             id: 1,
-             event_type: "state_changed",
-         };
-         let v: serde_json::Value =
-             serde_json::from_str(&serde_json::to_string(&msg).unwrap()).unwrap();
-         assert_eq!(v["type"], "subscribe_events");
-         assert_eq!(v["id"], 1);
-         assert_eq!(v["event_type"], "state_changed");
-     }
+    #[test]
+    fn subscribe_events_has_correct_wire_format() {
+        let msg = ClientMsg::SubscribeEvents {
+            id: 1,
+            event_type: "state_changed",
+        };
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&msg).unwrap()).unwrap();
+        assert_eq!(v["type"], "subscribe_events");
+        assert_eq!(v["id"], 1);
+        assert_eq!(v["event_type"], "state_changed");
+    }
 
-     #[test]
-     fn token_with_special_chars_survives_roundtrip() {
-         let msg = ClientMsg::Auth {
-             access_token: "ab\"c\ne\\f",
-         };
-         let json = serde_json::to_string(&msg).unwrap();
-         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-         assert_eq!(v["access_token"], "ab\"c\ne\\f");
-     }
+    #[test]
+    fn token_with_special_chars_survives_roundtrip() {
+        let msg = ClientMsg::Auth {
+            access_token: "ab\"c\ne\\f",
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["access_token"], "ab\"c\ne\\f");
+    }
 
-     #[test]
-     fn unicode_in_token_survives_roundtrip() {
-         let msg = ClientMsg::Auth {
-             access_token: "č🦀ü",
-         };
-         let json = serde_json::to_string(&msg).unwrap();
-         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-         assert_eq!(v["access_token"], "č🦀ü");
-     }
- }
+    #[test]
+    fn unicode_in_token_survives_roundtrip() {
+        let msg = ClientMsg::Auth {
+            access_token: "č🦀ü",
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["access_token"], "č🦀ü");
+    }
+}
 
- // ================================================================
- // Sanity checks pro konstanty — zachytí bugy typu "překlep v čísle"
- // ================================================================
- mod constants {
-     use super::*;
+// ================================================================
+// Sanity checks pro konstanty — zachytí bugy typu "překlep v čísle"
+// ================================================================
+mod constants {
+    use super::*;
 
-     #[test]
-     fn backoff_bounds_are_sane() {
-         assert!(INITIAL_BACKOFF <= MAX_BACKOFF);
-         assert!(INITIAL_BACKOFF > Duration::ZERO);
-     }
+    #[test]
+    fn backoff_bounds_are_sane() {
+        assert!(INITIAL_BACKOFF <= MAX_BACKOFF);
+        assert!(INITIAL_BACKOFF > Duration::ZERO);
+    }
 
-     #[test]
-     fn heartbeat_fires_before_stale_threshold() {
-         // musíme pingnout aspoň jednou před tím, než bychom prohlásili stale
-         // jinak by se spojení ukončilo dřív, než by vůbec mělo šanci
-         assert!(HEARTBEAT_INTERVAL < STALE_AFTER);
-     }
+    #[test]
+    fn heartbeat_fires_before_stale_threshold() {
+        // musíme pingnout aspoň jednou před tím, než bychom prohlásili stale
+        // jinak by se spojení ukončilo dřív, než by vůbec mělo šanci
+        assert!(HEARTBEAT_INTERVAL < STALE_AFTER);
+    }
 
-     #[test]
-     fn auth_failures_bound_is_positive() {
-         // 0 by znamenalo "okamžitě vzdej", nemá smysl
-         assert!(MAX_AUTH_FAILURES > 0);
-     }
+    #[test]
+    fn auth_failures_bound_is_positive() {
+        // 0 by znamenalo "okamžitě vzdej", nemá smysl
+        const { assert!(MAX_AUTH_FAILURES > 0) }
+    }
 
-     #[test]
-     fn event_channel_has_capacity() {
-         assert!(EVENT_CHANNEL_CAPACITY > 0);
-     }
- }
-
+    #[test]
+    fn event_channel_has_capacity() {
+        const { assert!(EVENT_CHANNEL_CAPACITY > 0) };
+    }
+}


### PR DESCRIPTION
- Split connect() into phased async functions (open_session, handshake, subscribe, pump_events) with explicit state transitions and a unified reconnect/backoff policy
- Introduce HaError enum (thiserror) replacing stringly-typed errors in HaEvent::Disconnected/AuthFailed; UI can now match on error classes (AuthInvalid, Stale, Protocol, Timeout, SendFailed, Closed, ...)
- Replace text.contains() message parsing with serde tagged ServerMsg/ClientMsg enums — wire-format type safety with #[serde(other)] forward-compat fallback
- Validate URLs via url::Url; invalid input fails fast instead of causing confusing connect errors on each reconnect
- 46 edge case tests in src/ha/ws/tests.rs (URL rewriting + serde round-trips for every ServerMsg variant)
