### PR TITLE
refactor: split into library + binary crates

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -173,7 +173,7 @@ impl Snapdash {
             ha_token_draft: String::new(),
             status: "-".into(),
             theme_options: vec![ThemeKind::MacLight, ThemeKind::MacDark],
-            windows: HashMap::new(), 
+            windows: HashMap::new(),
             pending_opens: VecDeque::new(),
             entities_by_id: HashMap::new(),
             entity_windows: HashMap::new(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -157,6 +157,12 @@ pub enum Message {
     LastVersionChecked(Option<update::GitHubRelease>),
 }
 
+impl Default for Snapdash {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Snapdash {
     pub fn new() -> Self {
         Self {
@@ -167,7 +173,7 @@ impl Snapdash {
             ha_token_draft: String::new(),
             status: "-".into(),
             theme_options: vec![ThemeKind::MacLight, ThemeKind::MacDark],
-            windows: HashMap::new(),
+            windows: HashMap::new(), 
             pending_opens: VecDeque::new(),
             entities_by_id: HashMap::new(),
             entity_windows: HashMap::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,32 @@
+pub mod app;
+pub mod config;
+pub mod ha;
+pub mod logger;
+pub mod secrets;
+pub mod theme;
+pub mod ui;
+pub mod update;
+
+use iced::daemon;
+
+/// Build and run the Snapdash daemon.
+///
+/// On Linux we install a custom `.style()` that clears the surface to
+/// `Color::TRANSPARENT` so the shadow-margin area around the card stays
+/// transparent (see `Snapdash::style` and `ui::platform`). On macOS and
+/// Windows the OS-level rounded-corner hack in iced_winit plus the
+/// card-filling-the-window layout make the default opaque theme clear
+/// color invisible, so we keep the iced default.
+pub fn run() -> iced::Result {
+    let builder = daemon(
+        app::Snapdash::boot,
+        app::Snapdash::update,
+        app::Snapdash::view,
+    )
+    .subscription(app::Snapdash::subscription);
+
+    #[cfg(target_os = "linux")]
+    let builder = builder.style(app::Snapdash::style);
+
+    builder.run()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,5 @@
 #![windows_subsystem = "windows"]
 
-mod app;
-mod config;
-mod ha;
-mod logger;
-mod secrets;
-mod theme;
-mod ui;
-mod update;
-
-use iced::daemon;
-
 fn main() -> iced::Result {
-    // On Linux we install a custom `.style()` that clears the surface to
-    // `Color::TRANSPARENT` so the shadow-margin area around the card stays
-    // transparent (see `Snapdash::style` and `ui::platform`). On macOS and
-    // Windows the OS-level rounded-corner hack in iced_winit plus the
-    // card-filling-the-window layout make the default opaque theme clear
-    // color invisible, so we keep the iced default.
-    let builder = daemon(
-        app::Snapdash::boot,
-        app::Snapdash::update,
-        app::Snapdash::view,
-    )
-    .subscription(app::Snapdash::subscription);
-
-    #[cfg(target_os = "linux")]
-    let builder = builder.style(app::Snapdash::style);
-
-    builder.run()
+    snapdash::run()
 }


### PR DESCRIPTION
Move module declarations and daemon setup into src/lib.rs, shrinking main.rs to a thin binary wrapper that calls snapdash::run().

This enables:
- cargo test --lib for unit tests in a pure library target
- tests/ integration tests consuming the public API
- cargo doc generating API documentation for all modules
- Code reuse if parts are ever extracted or consumed separately