### PR TITLE
refactor(logger): migrate to structured logging via tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +674,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +755,15 @@ dependencies = [
  "dbus",
  "openssl",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1900,6 +1927,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2015,6 +2048,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -2160,6 +2202,21 @@ dependencies = [
  "libc",
  "memoffset",
 ]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -2810,6 +2867,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3014,6 +3077,23 @@ dependencies = [
  "libredox",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "renderdoc-sys"
@@ -3358,6 +3438,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3491,6 +3580,9 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "toml",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -3584,6 +3676,12 @@ dependencies = [
  "yazi",
  "zeno",
 ]
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -3685,6 +3783,46 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3922,14 +4060,27 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3945,11 +4096,41 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4072,6 +4253,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,10 @@ tokio-tungstenite = { version = "0.29.0", features = [
 ] }
 toml = "1.1.2"
 url = "2.5.8"
+tracing = { version = "0.1.44", features = ["log"] }
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+tracing-appender = "0.2.5"
+
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "3.6.3", features = ["apple-native"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use crate::ha::{EntityState, HaConnectionConfig, HaEvent};
 use crate::logger::LogType;
-use crate::{logger as log, update};
+use crate::update;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant};
 
@@ -443,9 +443,9 @@ impl Snapdash {
     pub fn set_status(&mut self, msg: impl Into<String>, error_type: LogType) {
         let msg = msg.into();
         match error_type {
-            LogType::Info => log::info(&msg),
-            LogType::Warn => log::warn(&msg),
-            LogType::Error => log::error(&msg),
+            LogType::Info => tracing::info!(target: "snapdash::status", "{msg}"),
+            LogType::Warn => tracing::warn!(target: "snapdash::status", "{msg}"),
+            LogType::Error => tracing::error!(target: "snapdash:status", "{msg}"),
             LogType::DoNotLog => (),
         }
         self.status = msg;
@@ -504,7 +504,7 @@ impl Snapdash {
                         self.config.ha_token_present = false;
                         self.ha_connection = None;
                         self.ha_connected = false;
-                        log::warn("HA disconnected due to erased token.");
+                        tracing::warn!("HA disconected due to erased token.");
                     }
                     Err(s) => {
                         self.set_status(s, LogType::Error);

--- a/src/ha/ws.rs
+++ b/src/ha/ws.rs
@@ -110,6 +110,7 @@ fn ws_url_from_http(ha_url: &str) -> Result<Url, HaError> {
     Ok(url)
 }
 
+#[tracing::instrument(skip_all, fields(url = %ws_url))]
 async fn open_session(token: &str, ws_url: &Url) -> Result<(WsSink, WsStream), HaError> {
     let (ws, _) = tokio_tungstenite::connect_async(ws_url.as_str())
         .await
@@ -130,6 +131,12 @@ async fn send_msg(
 ) -> Result<(), HaError> {
     let json = serde_json::to_string(msg).map_err(|e| HaError::Protocol(e.to_string()))?;
 
+    // do not log auth token!
+    if !matches!(msg, ClientMsg::Auth { .. }) {
+        tracing::trace!(what, payload = %json, "→ send");
+    } else {
+        tracing::trace!(what, "→ send (payload redacted)");
+    }
     sink.send(WsMessage::Text(Utf8Bytes::from(json)))
         .await
         .map_err(|_| HaError::SendFailed { what })
@@ -141,6 +148,7 @@ async fn read_msg<T: serde::de::DeserializeOwned>(stream: &mut WsStream) -> Resu
             Some(Err(e)) => return Err(HaError::Protocol(e.to_string())),
             Some(Ok(WsMessage::Close(_))) | None => return Err(HaError::Closed),
             Some(Ok(WsMessage::Text(text))) => {
+                tracing::trace!(raw = text.as_str(), "← recv");
                 return serde_json::from_str(text.as_str())
                     .map_err(|e| HaError::Protocol(e.to_string()));
             }
@@ -160,10 +168,14 @@ async fn expect<T: DeserializeOwned>(
         .map_err(|_| HaError::Timeout { what })?
 }
 
+#[tracing::instrument(skip_all)]
 async fn handshake(sink: &mut WsSink, stream: &mut WsStream, token: &str) -> Result<(), HaError> {
     // expect auth_required
+    tracing::debug!("waiting for auth_required");
     match expect::<ServerMsg>(stream, HANDSHAKE_TIMEOUT, "auth_required").await? {
-        ServerMsg::AuthRequired { .. } => {}
+        ServerMsg::AuthRequired { ha_version } => {
+            tracing::info!(%ha_version, "authenticating")
+        }
         other => {
             return Err(HaError::Protocol(format!(
                 "expected auth_required, got {other:?}"
@@ -172,6 +184,7 @@ async fn handshake(sink: &mut WsSink, stream: &mut WsStream, token: &str) -> Res
     }
 
     // send auth
+    tracing::debug!("sending auth");
     send_msg(
         sink,
         &ClientMsg::Auth {
@@ -182,8 +195,13 @@ async fn handshake(sink: &mut WsSink, stream: &mut WsStream, token: &str) -> Res
     .await?;
 
     // expect auth_ok / auth_invalid
+
+    tracing::debug!("waiting for auth result");
     match expect::<ServerMsg>(stream, HANDSHAKE_TIMEOUT, "auth_result").await? {
-        ServerMsg::AuthOk { .. } => Ok(()),
+        ServerMsg::AuthOk { .. } => {
+            tracing::debug!("auth succeeded");
+            Ok(())
+        }
         ServerMsg::AuthInvalid { message } => Err(HaError::AuthInvalid(message)),
         other => Err(HaError::Protocol(format!(
             "unexpected during auth: {other:?}"
@@ -191,6 +209,7 @@ async fn handshake(sink: &mut WsSink, stream: &mut WsStream, token: &str) -> Res
     }
 }
 
+#[tracing::instrument(skip_all)]
 async fn subscribe(sink: &mut WsSink) -> Result<(), HaError> {
     send_msg(
         sink,
@@ -203,6 +222,7 @@ async fn subscribe(sink: &mut WsSink) -> Result<(), HaError> {
     .await
 }
 
+#[tracing::instrument(skip_all)]
 async fn pump_events(
     sink: &mut WsSink,
     stream: &mut WsStream,
@@ -231,10 +251,8 @@ async fn pump_events(
 
                 let msg: ServerMsg = match serde_json::from_str(text.as_str()) {
                     Ok(m) => m,
-                    Err(_) => {
-                        // consider to create tracing. Eg: tracing::warn!(error = %e, raw = %text.as_str(), "failed to decode ServerMsg");
-                        // but this is suitable for now
-                        // tracing::warn!(error = %e, raw = %text.as_str(), "failed to decode ServerMsg");
+                    Err(e) => {
+                        tracing::warn!(error = %e, raw = text.as_str(), "failed to decode ServerMsg - skipping");
                         continue;
                     }
                 };
@@ -243,6 +261,11 @@ async fn pump_events(
                     && event.event_type == "state_changed"
                     && let Some(new_state) = event.data.new_state
                 {
+                    tracing::trace!(
+                        entity_id = %new_state.entity_id,
+                        state = %new_state.state,
+                        "state_changed"
+                    );
                     let _ = out.send(HaEvent::StateChanged { new_state }).await;
                 }
             }
@@ -251,6 +274,7 @@ async fn pump_events(
                 if last_received.elapsed() > STALE_AFTER {
                     return HaError::Stale { elapsed: last_received.elapsed() };
                 }
+                tracing::trace!("sending heartbeat ping");
                 if sink.send(WsMessage::Ping(Bytes::new())).await.is_err() {
                     return HaError::SendFailed { what: "ping" };
                 }
@@ -266,6 +290,7 @@ pub fn connect(config: &HaConnectionConfig) -> BoxStream<'static, HaEvent> {
         let ws_url = match ws_url_from_http(&cfg.url) {
             Ok(u) => u,
             Err(e) => {
+                tracing::error!(url= %cfg.url, error = %e, "invalid HA URL - stream ending");
                 let _ = out.send(HaEvent::Disconnected(e)).await;
                 return;
             }
@@ -277,6 +302,7 @@ pub fn connect(config: &HaConnectionConfig) -> BoxStream<'static, HaEvent> {
         loop {
             let (mut sink, mut stream) = match open_session(&cfg.token, &ws_url).await {
                 Ok(ws) => {
+                    tracing::info!("connected and subscribed to state_changed events");
                     auth_failures = 0;
                     backoff = INITIAL_BACKOFF;
                     ws
@@ -286,6 +312,10 @@ pub fn connect(config: &HaConnectionConfig) -> BoxStream<'static, HaEvent> {
                     let _ = out.send(HaEvent::Disconnected(e)).await;
 
                     if auth_failures >= MAX_AUTH_FAILURES {
+                        tracing::error!(
+                            attempts = auth_failures,
+                            "authentication exhausted - giving up"
+                        );
                         let _ = out
                             .send(HaEvent::AuthFailed(HaError::AuthExhausted {
                                 attempts: auth_failures,
@@ -293,10 +323,16 @@ pub fn connect(config: &HaConnectionConfig) -> BoxStream<'static, HaEvent> {
                             .await;
                         return; // stream ended
                     }
+                    tracing::warn!(
+                        attempt = auth_failures,
+                        max = MAX_AUTH_FAILURES,
+                        "authentication rejected - retrying"
+                    );
                     sleep(AUTH_RETRY_DELAY).await;
                     continue;
                 }
                 Err(e) => {
+                    tracing::warn!(error = %e, backoff_s = backoff.as_secs(), "reconnecting");
                     let _ = out.send(HaEvent::Disconnected(e)).await;
                     sleep(backoff).await;
                     backoff = (backoff * 2).min(MAX_BACKOFF);
@@ -307,6 +343,9 @@ pub fn connect(config: &HaConnectionConfig) -> BoxStream<'static, HaEvent> {
             // Autenticated + subscribed
             let _ = out.send(HaEvent::Connected).await;
             let initial = rest::fetch_all_states(&cfg.url, &cfg.token).await;
+
+            tracing::debug!(count = initial.len(), "received initial states");
+
             let _ = out.send(HaEvent::InitialState(initial)).await;
 
             // run Forrest, run!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use iced::daemon;
 /// card-filling-the-window layout make the default opaque theme clear
 /// color invisible, so we keep the iced default.
 pub fn run() -> iced::Result {
-    let _gurad = logger::init().expect("failed to initialize logger");
+    let _gurad = logger::init();
 
     tracing::info!(version = env!("CARGO_PKG_VERSION"), "snapdash starting");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,10 @@ use iced::daemon;
 /// card-filling-the-window layout make the default opaque theme clear
 /// color invisible, so we keep the iced default.
 pub fn run() -> iced::Result {
+    let _gurad = logger::init().expect("failed to initialize logger");
+
+    tracing::info!(version = env!("CARGO_PKG_VERSION"), "snapdash starting");
+
     let builder = daemon(
         app::Snapdash::boot,
         app::Snapdash::update,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use directories::ProjectDirs;
 
-use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 /// UI status hint
@@ -18,16 +18,59 @@ pub enum LogType {
 
 /// Initialize the global tracing subscriber.
 ///
-/// Returns a `WorkerGuard` that **must be kept alive** for the lifetime of the
-/// process — dropping it flushes any pending log lines from the non-blocking
-/// file writer.
+/// Always installs a stdout layer. File-logging is *best-effort*: if we
+/// cannot create or open the log file (read-only fs, permission denied,
+/// sandbox restriction), the reason is written to stderr and the app
+/// continues with stdout-only logging. File logging is not a startup
+/// prerequisite.
 ///
-/// Env var `RUST_LOG` controls filtering; default is `snapdash=info,warn`.
-pub fn init() -> anyhow::Result<WorkerGuard> {
+/// Returns `Some(WorkerGuard)` when the file layer is active — the guard
+/// must be kept alive for the process lifetime so pending writes flush on
+/// exit. `None` means stdout-only logging is in effect.
+pub fn init() -> Option<WorkerGuard> {
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("snapdash=info,warn"));
+
+    let stdout_layer = fmt::layer().with_writer(std::io::stdout).pretty();
+
+    match try_file_writer() {
+        Ok((non_blocking, guard)) => {
+            let file_layer = fmt::layer()
+                .with_writer(non_blocking)
+                .with_ansi(false)
+                .with_target(true);
+
+            tracing_subscriber::registry()
+                .with(filter)
+                .with(stdout_layer)
+                .with(file_layer)
+                .init();
+
+            Some(guard)
+        }
+        Err(e) => {
+            // Subscriber is not installed - use stderr directly.
+            eprintln!("warning: file logging disabled: {e:#}");
+
+            tracing_subscriber::registry()
+                .with(filter)
+                .with(stdout_layer)
+                .init();
+
+            tracing::warn!(error = %e, "file logging disabled; stdout only");
+
+            None
+        }
+    }
+
+}
+
+fn try_file_writer() -> anyhow::Result<(NonBlocking, WorkerGuard)> {
     let log_path = log_path()?;
 
     if let Some(parent) = log_path.parent() {
-        std::fs::create_dir_all(parent)?;
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("cannot create log dir {}", parent.display()))?;
     }
 
     let file = OpenOptions::new()
@@ -37,24 +80,7 @@ pub fn init() -> anyhow::Result<WorkerGuard> {
         .with_context(|| format!("cannot open log file {}", log_path.display()))?;
 
     let (non_blocking, guard) = tracing_appender::non_blocking(file);
-
-    let filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("snapdash=info,warn"));
-
-    let file_layer = fmt::layer()
-        .with_writer(non_blocking)
-        .with_ansi(false)
-        .with_target(true);
-
-    let stdout_layer = fmt::layer().with_writer(std::io::stdout).pretty();
-
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(stdout_layer)
-        .with(file_layer)
-        .init();
-
-    Ok(guard)
+    Ok((non_blocking, guard))
 }
 
 fn log_path() -> anyhow::Result<PathBuf> {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,10 +1,14 @@
-use std::fs::{OpenOptions, create_dir_all};
-use std::io::Write;
+use std::fs::OpenOptions;
 use std::path::PathBuf;
-use std::sync::OnceLock;
 
+use anyhow::Context;
 use directories::ProjectDirs;
 
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+/// UI status hint
+#[derive(Clone, Copy, Debug)]
 pub enum LogType {
     Info,
     Warn,
@@ -12,40 +16,49 @@ pub enum LogType {
     DoNotLog,
 }
 
-static LOG_FILE: OnceLock<PathBuf> = OnceLock::new();
+/// Initialize the global tracing subscriber.
+///
+/// Returns a `WorkerGuard` that **must be kept alive** for the lifetime of the
+/// process — dropping it flushes any pending log lines from the non-blocking
+/// file writer.
+///
+/// Env var `RUST_LOG` controls filtering; default is `snapdash=info,warn`.
+pub fn init() -> anyhow::Result<WorkerGuard> {
+    let log_path = log_path()?;
 
-pub fn error(msg: impl AsRef<str>) {
-    append(&format!("ERROR: {}", msg.as_ref()));
-}
-
-pub fn warn(msg: impl AsRef<str>) {
-    append(&format!("WARNING: {}", msg.as_ref()));
-}
-
-pub fn info(msg: impl AsRef<str>) {
-    append(&format!("INFO: {}", msg.as_ref()));
-}
-
-fn log_path() -> &'static PathBuf {
-    LOG_FILE.get_or_init(|| {
-        let proj = ProjectDirs::from("dev", "snapdash", "Snapdash")
-            .expect("cannot determine app data dir");
-
-        let dir = proj.data_dir();
-        create_dir_all(dir).ok();
-
-        dir.join("debug.log")
-    })
-}
-
-fn append(msg: &str) {
-    let path = log_path();
-
-    let now = std::time::SystemTime::now();
-    let ts = chrono::DateTime::<chrono::Local>::from(now).format("%Y-%m-%d %H:%M:%S%.3f");
-    let line = format!("{ts} {msg}");
-
-    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
-        let _ = writeln!(file, "{line}");
+    if let Some(parent) = log_path.parent() {
+        std::fs::create_dir_all(parent)?;
     }
+
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .with_context(|| format!("cannot open log file {}", log_path.display()))?;
+
+    let (non_blocking, guard) = tracing_appender::non_blocking(file);
+
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("snapdash=info,warn"));
+
+    let file_layer = fmt::layer()
+        .with_writer(non_blocking)
+        .with_ansi(false)
+        .with_target(true);
+
+    let stdout_layer = fmt::layer().with_writer(std::io::stdout).pretty();
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(stdout_layer)
+        .with(file_layer)
+        .init();
+
+    Ok(guard)
+}
+
+fn log_path() -> anyhow::Result<PathBuf> {
+    let proj = ProjectDirs::from("dev", "snapdash", "Snapdash")
+        .context("cannot determine app data dir")?;
+    Ok(proj.data_dir().join("debug.log"))
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -62,7 +62,6 @@ pub fn init() -> Option<WorkerGuard> {
             None
         }
     }
-
 }
 
 fn try_file_writer() -> anyhow::Result<(NonBlocking, WorkerGuard)> {


### PR DESCRIPTION
## Summary
- Replace ad-hoc logger file writers with tracing ecosystem
- Global subscriber writes to both stdout (pretty) + debug.log (plain)
- `#[tracing::instrument]` spans on key async fns in ha::ws
- Structured fields instead of stringified messages
- Auth token redacted in trace-level logsReplace the ad-hoc logger::{info,warn,error} file writers with the tracing ecosystem. A global subscriber now emits structured events to both stdout (pretty) and debug.log (plain), with RUST_LOG-based runtime filtering.

Changes:
- logger::init() configures tracing-subscriber (env-filter, file layer via tracing-appender non-blocking, stdout layer); returns a WorkerGuard that lib::run() holds for the program lifetime
- app::set_status emits tracing events at target "snapdash::status" instead of calling the old file writer; LogType::DoNotLog still means UI-only transient message
- ha::ws: #[instrument] spans on open_session, handshake, subscribe, pump_events with structured fields (url, attempt, backoff_s, entity_id, …); auth frame payload redacted in trace logs to prevent token leak in shared debug output

Default filter: snapdash=info,warn. For deep wire debugging: RUST_LOG=snapdash::ha::ws=trace