### PR TITLE
feat(ui): release notes window on update-available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,6 +1212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +1727,7 @@ dependencies = [
  "iced_renderer",
  "log",
  "num-traits",
+ "pulldown-cmark",
  "rustc-hash 2.1.1",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -1881,6 +1891,25 @@ checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -2696,6 +2725,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "open"
+version = "5.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2826,6 +2866,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2974,6 +3020,25 @@ name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags 2.10.0",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quick-xml"
@@ -3666,6 +3731,7 @@ dependencies = [
  "directories",
  "iced",
  "keyring",
+ "open",
  "rand 0.10.1",
  "reqwest",
  "serde",
@@ -4276,6 +4342,12 @@ dependencies = [
  "tempfile",
  "winapi",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayref"
@@ -494,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -2017,9 +2017,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
@@ -2183,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -3748,12 +3748,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4050,9 +4050,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -4065,9 +4065,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,16 @@ categories = ["gui", "visualization", "rendering"]
 rust-version = "1.94"
 
 exclude = [
-  "/.github/",
-  "/.vscode/",
-  "/.zed/",
-  "/.claude/",
-  "/dist/",
-  "/assets/screenshots/",
-  "*.png",
-  "*.gif",
-  ".DS_Store",
-  "mac_build.sh",
+    "/.github/",
+    "/.vscode/",
+    "/.zed/",
+    "/.claude/",
+    "/dist/",
+    "/assets/screenshots/",
+    "*.png",
+    "*.gif",
+    ".DS_Store",
+    "mac_build.sh",
 ]
 
 [features]
@@ -33,25 +33,25 @@ diagnostics = []
 [dependencies]
 anyhow = "1.0.100"
 chrono = { version = "0.4.42", default-features = false, features = ["clock"] }
-iced = { version = "0.14.0", features = ["wgpu", "tokio"] }
+iced = { version = "0.14.0", features = ["wgpu", "tokio", "markdown"] }
 directories = "6.0.0"
 thiserror = "2.0.18"
 
 reqwest = { version = "0.13.2", default-features = false, features = [
-  "json",
-  "rustls",
-  "http2",
+    "json",
+    "rustls",
+    "http2",
 ] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.48.0", features = [
-  "macros",
-  "rt-multi-thread",
-  "time",
-  "fs",
+    "macros",
+    "rt-multi-thread",
+    "time",
+    "fs",
 ] }
 tokio-tungstenite = { version = "0.29.0", features = [
-  "rustls-tls-webpki-roots",
+    "rustls-tls-webpki-roots",
 ] }
 toml = "1.1.2"
 url = "2.5.8"
@@ -59,6 +59,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tracing-appender = "0.2.5"
 rand = "0.10.1"
+open = "5.3.4"
 
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ default = ["diagnostics"]
 diagnostics = []
 
 [dependencies]
-anyhow = "1.0.100"
-chrono = { version = "0.4.42", default-features = false, features = ["clock"] }
+anyhow = "1.0.102"
+chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
 iced = { version = "0.14.0", features = ["wgpu", "tokio", "markdown"] }
 directories = "6.0.0"
 thiserror = "2.0.18"
@@ -44,7 +44,7 @@ reqwest = { version = "0.13.2", default-features = false, features = [
 ] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-tokio = { version = "1.48.0", features = [
+tokio = { version = "1.52.1", features = [
     "macros",
     "rt-multi-thread",
     "time",

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,6 +16,7 @@ use crate::theme::ThemeKind;
 pub enum WindowKind {
     Settings,
     Entity { entity_id: String },
+    ReleaseNotes,
 }
 #[derive(Debug)]
 pub struct WindowState {
@@ -111,7 +112,10 @@ pub struct Snapdash {
 
     pub entity_search_query: String,
     pub debug_now: Instant,
+
     pub update_state: UpdateState,
+    pub latest_release: Option<update::GitHubRelease>,
+    pub release_notes_items: Vec<iced::widget::markdown::Item>,
 }
 
 #[derive(Debug, Clone)]
@@ -119,6 +123,8 @@ pub enum Message {
     Noop,
     OpenSettings,
     OpenEntity(String),
+    OpenReleaseNotes,
+    OpenUrl(String),
     CloseWindow(window::Id),
     QuitApp,
     WindowClosed(window::Id),
@@ -185,6 +191,8 @@ impl Snapdash {
             entity_search_query: String::new(),
             debug_now: Instant::now(),
             update_state: UpdateState::Unknown,
+            latest_release: None,
+            release_notes_items: Vec::new(),
         }
     }
     pub fn boot() -> (Self, Task<Message>) {
@@ -858,13 +866,42 @@ impl Snapdash {
             }
 
             Message::LastVersionChecked(release) => {
-                if release.is_some() {
+                if let Some(release) = release {
                     self.update_state = UpdateState::UpdateAvailable;
-                    Task::none()
+                    self.release_notes_items =
+                        iced::widget::markdown::parse(&release.body).collect();
+                    self.latest_release = Some(release);
                 } else {
                     self.update_state = UpdateState::UptoDate;
-                    Task::none()
+                    self.latest_release = None;
+                    self.release_notes_items.clear();
                 }
+                Task::none()
+            }
+            Message::OpenReleaseNotes => {
+                if let Some(opened) =
+                    Snapdash::find_window_id(&self.windows, WindowKind::ReleaseNotes, None)
+                {
+                    return iced::window::gain_focus::<Message>(opened);
+                }
+
+                self.pending_opens.push_back(WindowKind::ReleaseNotes);
+                let settings = window::Settings {
+                    size: crate::ui::platform::window_size(560.0, 640.0),
+                    resizable: true,
+                    decorations: false,
+                    transparent: true,
+                    ..window::Settings::default()
+                };
+
+                let (_id, task_id) = window::open(settings);
+                task_id.map(Message::WindowActuallyOpened)
+            }
+            Message::OpenUrl(url) => {
+                if let Err(e) = open::that(&url) {
+                    tracing::warn!(url, error = %e, "failed to open URL");
+                }
+                Task::none()
             }
         }
     }
@@ -883,6 +920,7 @@ impl Snapdash {
                 crate::ui::chrome::with_mouse_area(with_gear, id, win)
             }
             WindowKind::Settings => inner,
+            WindowKind::ReleaseNotes => inner,
         };
 
         // Platform-specific outer wrapping:

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -23,6 +23,7 @@ pub fn window_content<'a>(
             app.ha_connected,
             app.update_state == UpdateState::UpdateAvailable,
         ),
+        WindowKind::ReleaseNotes => crate::ui::release_notes::view(app, id),
     }
 }
 
@@ -159,5 +160,6 @@ pub fn with_mouse_area<'a>(
     match win.kind {
         WindowKind::Entity { .. } => ma.on_press(Message::StartDrag(id)).into(),
         WindowKind::Settings => ma.into(),
+        WindowKind::ReleaseNotes => ma.into(),
     }
 }

--- a/src/ui/components.rs
+++ b/src/ui/components.rs
@@ -381,7 +381,7 @@ pub fn active_sensor_section(app: &crate::app::Snapdash, p: Palette) -> Element<
         col = col.push(row_el);
     }
 
-    scrollable(col.into(), p).into()
+    scrollable(col.into(), p).height(Length::Fill).into()
 }
 
 pub fn sensors_section(app: &crate::app::Snapdash, p: Palette) -> Element<'_, Message> {

--- a/src/ui/components.rs
+++ b/src/ui/components.rs
@@ -1,7 +1,6 @@
 use iced::overlay::menu;
-use iced::widget::{
-    button, checkbox, column, container, pick_list, row, scrollable, stack, text, text_input,
-};
+use iced::widget::scrollable::{AutoScroll, Rail, Scroller, Status, Style};
+use iced::widget::{button, checkbox, column, container, pick_list, row, stack, text, text_input};
 use iced::{Background, Border, Element, Length};
 
 use crate::app::Message;
@@ -382,55 +381,7 @@ pub fn active_sensor_section(app: &crate::app::Snapdash, p: Palette) -> Element<
         col = col.push(row_el);
     }
 
-    let scroll = scrollable(col)
-        .height(Length::Fill)
-        .style(move |_: &iced::Theme, _| iced::widget::scrollable::Style {
-            container: iced::widget::container::Style {
-                background: Some(iced::Background::Color(p.card)),
-                border: Border {
-                    radius: 20.0.into(),
-                    width: 0.0,
-                    color: p.border,
-                },
-                text_color: Some(p.accent_dim),
-                ..Default::default()
-            },
-            vertical_rail: iced::widget::scrollable::Rail {
-                background: Some(iced::Background::Color(p.accent_tint)),
-                scroller: iced::widget::scrollable::Scroller {
-                    background: iced::Background::Color(p.accent),
-                    border: Border {
-                        color: p.accent_dim,
-                        width: 0.3,
-                        radius: 20.0.into(),
-                    },
-                },
-                border: Border {
-                    color: p.border,
-                    width: 0.3,
-                    radius: 20.0.into(),
-                },
-            },
-            horizontal_rail: iced::widget::scrollable::Rail {
-                background: Some(iced::Background::Color(p.accent_dim)),
-                scroller: iced::widget::scrollable::Scroller {
-                    background: iced::Background::Color(p.accent_dim),
-                    border: iced::Border::default(),
-                },
-                border: iced::Border::default(),
-            },
-            gap: None,
-            auto_scroll: iced::widget::scrollable::AutoScroll {
-                background: iced::Background::Color(p.accent_dim),
-                border: iced::Border::default(),
-                icon: p.bg,
-                shadow: iced::Shadow {
-                    ..Default::default()
-                },
-            },
-        });
-
-    scroll.into()
+    scrollable(col.into(), p).into()
 }
 
 pub fn sensors_section(app: &crate::app::Snapdash, p: Palette) -> Element<'_, Message> {
@@ -481,55 +432,59 @@ pub fn sensors_section(app: &crate::app::Snapdash, p: Palette) -> Element<'_, Me
         col = col.push(row_el);
     }
 
-    let scroll = scrollable(col)
-        .height(Length::Fill)
-        .style(move |_: &iced::Theme, _| iced::widget::scrollable::Style {
-            container: iced::widget::container::Style {
-                background: Some(iced::Background::Color(p.card)),
-                border: Border {
-                    radius: 20.0.into(),
-                    width: 0.0,
-                    color: p.border,
-                },
-                text_color: Some(p.accent_dim),
+    scrollable(col.into(), p).height(Length::Fill).into()
+}
+
+pub fn scrollable<'a>(
+    content: Element<'a, Message>,
+    p: Palette,
+) -> iced::widget::Scrollable<'a, Message> {
+    iced::widget::scrollable(content).style(move |_theme, status| {
+        let is_interacting = matches!(
+            status,
+            Status::Hovered {
+                is_horizontal_scrollbar_hovered: true,
+                ..
+            } | Status::Hovered {
+                is_vertical_scrollbar_hovered: true,
+                ..
+            } | Status::Dragged { .. }
+        );
+
+        let scroller_color = if is_interacting {
+            p.accent_dim
+        } else {
+            p.border_hovered
+        };
+
+        let rail = Rail {
+            background: Some(iced::Background::Color(p.accent_tint)),
+            border: iced::Border {
+                radius: 4.0.into(),
                 ..Default::default()
             },
-            vertical_rail: iced::widget::scrollable::Rail {
-                background: Some(iced::Background::Color(p.accent_tint)),
-                scroller: iced::widget::scrollable::Scroller {
-                    background: iced::Background::Color(p.accent),
-                    border: Border {
-                        color: p.accent_dim,
-                        width: 0.3,
-                        radius: 20.0.into(),
-                    },
-                },
-                border: Border {
-                    color: p.border,
-                    width: 0.3,
-                    radius: 20.0.into(),
-                },
-            },
-            horizontal_rail: iced::widget::scrollable::Rail {
-                background: Some(iced::Background::Color(p.accent_dim)),
-                scroller: iced::widget::scrollable::Scroller {
-                    background: iced::Background::Color(p.accent_dim),
-                    border: iced::Border::default(),
-                },
-                border: iced::Border::default(),
-            },
-            gap: None,
-            auto_scroll: iced::widget::scrollable::AutoScroll {
-                background: iced::Background::Color(p.accent_dim),
-                border: iced::Border::default(),
-                icon: p.bg,
-                shadow: iced::Shadow {
+            scroller: Scroller {
+                background: iced::Background::Color(scroller_color),
+                border: iced::Border {
+                    radius: 4.0.into(),
                     ..Default::default()
                 },
             },
-        });
+        };
 
-    scroll.into()
+        Style {
+            container: iced::widget::container::Style::default(),
+            vertical_rail: rail,
+            horizontal_rail: rail,
+            gap: None,
+            auto_scroll: AutoScroll {
+                background: iced::Background::Color(p.accent_tint),
+                border: iced::Border::default(),
+                icon: p.text_body,
+                shadow: iced::Shadow::default(),
+            },
+        }
+    })
 }
 
 pub fn fieldset<'a>(

--- a/src/ui/entity_window.rs
+++ b/src/ui/entity_window.rs
@@ -1,4 +1,4 @@
-use iced::widget::{MouseArea, column, mouse_area, row, space, text, tooltip};
+use iced::widget::{column, mouse_area, row, space, text};
 use iced::{Alignment, Element, Length};
 
 use super::components;
@@ -66,16 +66,16 @@ pub fn view(
     let (friendly, main_opt, detail) = format_main_value(state);
 
     let update_icon: Element<Message> = if update {
-        
-        mouse_area(
-        components::dimmed(
+        mouse_area(components::dimmed(
             '⤓',
             crate::theme::Palette {
                 text_dim: iced::Color::from_rgb8(255, 0, 0),
                 ..p
             },
-        )).on_press(Message::OpenReleaseNotes).interaction(iced::mouse::Interaction::Pointer).into()
-        
+        ))
+        .on_press(Message::OpenReleaseNotes)
+        .interaction(iced::mouse::Interaction::Pointer)
+        .into()
     } else {
         components::dimmed("", p).into()
     };

--- a/src/ui/entity_window.rs
+++ b/src/ui/entity_window.rs
@@ -1,4 +1,4 @@
-use iced::widget::{column, row, space, text};
+use iced::widget::{MouseArea, column, mouse_area, row, space, text, tooltip};
 use iced::{Alignment, Element, Length};
 
 use super::components;
@@ -65,16 +65,19 @@ pub fn view(
 ) -> Element<'_, Message> {
     let (friendly, main_opt, detail) = format_main_value(state);
 
-    let update_icon = if update {
+    let update_icon: Element<Message> = if update {
+        
+        mouse_area(
         components::dimmed(
-            '⟳',
+            '⤓',
             crate::theme::Palette {
                 text_dim: iced::Color::from_rgb8(255, 0, 0),
                 ..p
             },
-        )
+        )).on_press(Message::OpenReleaseNotes).interaction(iced::mouse::Interaction::Pointer).into()
+        
     } else {
-        components::dimmed("", p)
+        components::dimmed("", p).into()
     };
     let title_text = if let Some(name) = friendly {
         row![

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,5 +3,6 @@ pub mod components;
 pub mod entity_window;
 pub mod format;
 pub mod platform;
+pub mod release_notes;
 pub mod settings;
 pub mod theme;

--- a/src/ui/release_notes.rs
+++ b/src/ui/release_notes.rs
@@ -1,0 +1,96 @@
+use iced::widget::{column, container, markdown, mouse_area, row, text};
+use iced::{Alignment, Element, Length, window};
+
+use crate::app::{Message, Snapdash};
+use crate::theme::metric;
+use crate::ui::components;
+
+pub fn view<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
+    let p = snap.theme.palette();
+
+    let Some(release) = &snap.latest_release else {
+        return components::card(
+            container(components::dimmed("No update available", p))
+                .center(Length::Fill)
+                .into(),
+            p,
+        );
+    };
+
+    let title_widget = text(format!("Latest version is {}", release.tag_name))
+        .size(18)
+        .style(move |_| text::Style {
+            color: Some(p.text_primary),
+        });
+
+    let title_bar: Element<Message> = row![
+        mouse_area(container(title_widget).width(Length::Fill).padding([4, 0]))
+            .on_press(Message::StartDrag(id)),
+        components::icon("✕", p, Some(Message::CloseWindow(id))),
+    ]
+    .align_y(Alignment::Center)
+    .into();
+
+    let version_line: Element<Message> = components::dimmed(
+        format!(
+            "Current: v{} → New: {}",
+            crate::update::CURRENT_VERSION,
+            release.tag_name
+        ),
+        p,
+    )
+    .into();
+
+    let md_theme: iced::Theme = match snap.theme {
+        crate::theme::ThemeKind::MacLight => iced::Theme::Light,
+        crate::theme::ThemeKind::MacDark => iced::Theme::Dark,
+    };
+
+    let base_md_style = markdown::Style::from_palette(md_theme.palette());
+    let md_style = markdown::Style {
+        inline_code_highlight: markdown::Highlight {
+            background: iced::Background::Color(p.accent_tint),
+            border: iced::Border {
+                radius: 4.0.into(),
+                ..Default::default()
+            },
+        },
+        inline_code_color: p.text_body,
+        link_color: p.accent,
+        ..base_md_style
+    };
+
+    let md_inner: Element<Message> = markdown::view(
+        &snap.release_notes_items,
+        markdown::Settings::with_text_size(13, md_style),
+    )
+    .map(Message::OpenUrl);
+
+    let md_view: Element<Message> = iced::widget::themer(Some(md_theme), md_inner)
+        .text_color(|theme: &iced::Theme| theme.palette().text)
+        .into();
+    
+    let md_scroll: Element<Message> = components::scrollable(
+        container(md_view).padding(metric::GAP).width(Length::Fill).into(),
+        p,
+        ).height(Length::Fill).into();
+
+
+    let actions: Element<Message> = row![
+        components::pill_button(
+            "Open on GitHub",
+            p,
+            Some(Message::OpenUrl(release.html_url.clone())),
+        ),
+        components::pill_button("Close", p, Some(Message::CloseWindow(id))),
+    ]
+    .spacing(metric::GAP)
+    .align_y(Alignment::Center)
+    .into();
+
+    let content: Element<Message> = column![title_bar, version_line, md_scroll, actions]
+        .spacing(metric::GAP)
+        .into();
+
+    components::card(content, p)
+}

--- a/src/ui/release_notes.rs
+++ b/src/ui/release_notes.rs
@@ -8,20 +8,14 @@ use crate::ui::components;
 pub fn view<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
     let p = snap.theme.palette();
 
-    let Some(release) = &snap.latest_release else {
-        return components::card(
-            container(components::dimmed("No update available", p))
-                .center(Length::Fill)
-                .into(),
-            p,
-        );
+    let title_text = match &snap.latest_release {
+        Some(r) => format!("Update to {}", r.tag_name),
+        None => "Release notes".to_owned(),
     };
 
-    let title_widget = text(format!("Latest version is {}", release.tag_name))
-        .size(18)
-        .style(move |_| text::Style {
-            color: Some(p.text_primary),
-        });
+    let title_widget = text(title_text).size(18).style(move |_| text::Style {
+        color: Some(p.text_primary),
+    });
 
     let title_bar: Element<Message> = row![
         mouse_area(container(title_widget).width(Length::Fill).padding([4, 0]))
@@ -30,6 +24,15 @@ pub fn view<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
     ]
     .align_y(Alignment::Center)
     .into();
+
+    let Some(release) = &snap.latest_release else {
+        let body: Element<Message> = container(components::dimmed("No update available", p))
+            .center(Length::Fill)
+            .height(Length::Fill)
+            .into();
+
+        return components::card(column![title_bar, body].spacing(metric::GAP).into(), p);
+    };
 
     let version_line: Element<Message> = components::dimmed(
         format!(

--- a/src/ui/release_notes.rs
+++ b/src/ui/release_notes.rs
@@ -69,12 +69,16 @@ pub fn view<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
     let md_view: Element<Message> = iced::widget::themer(Some(md_theme), md_inner)
         .text_color(|theme: &iced::Theme| theme.palette().text)
         .into();
-    
-    let md_scroll: Element<Message> = components::scrollable(
-        container(md_view).padding(metric::GAP).width(Length::Fill).into(),
-        p,
-        ).height(Length::Fill).into();
 
+    let md_scroll: Element<Message> = components::scrollable(
+        container(md_view)
+            .padding(metric::GAP)
+            .width(Length::Fill)
+            .into(),
+        p,
+    )
+    .height(Length::Fill)
+    .into();
 
     let actions: Element<Message> = row![
         components::pill_button(

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "diagnostics")]
 use iced::widget::checkbox;
 use iced::widget::{column, container, mouse_area, row};
-use iced::{Element, Length};
+use iced::{Element, Length, mouse};
 
 use crate::app::{Message, Snapdash, UpdateState};
 use crate::theme::metric;
@@ -53,12 +53,21 @@ pub fn view(snap: &Snapdash, id: iced::window::Id) -> Element<'_, Message> {
             },
         ),
         UpdateState::UpdateAvailable => dimmed(
-            '⟳',
+            '⤓',
             crate::theme::Palette {
                 text_dim: iced::Color::from_rgb8(255, 0, 0),
                 ..p
             },
         ),
+    };
+
+    let update_icon: Element<Message> = if snap.update_state == UpdateState::UpdateAvailable {
+        mouse_area(update_icon)
+            .on_press(Message::OpenReleaseNotes)
+            .interaction(iced::mouse::Interaction::Pointer)
+            .into()
+    } else {
+        update_icon.into()
     };
 
     let version: Element<Message> = row![
@@ -133,6 +142,15 @@ pub fn view(snap: &Snapdash, id: iced::window::Id) -> Element<'_, Message> {
         p,
     );
 
+    let update_badge: Element<Message> = if snap.update_state == UpdateState::UpdateAvailable {
+        mouse_area(components::badge("Update Available", p))
+            .on_press(Message::OpenReleaseNotes)
+            .interaction(mouse::Interaction::Pointer)
+            .into()
+    } else {
+        iced::widget::space().width(0).height(0).into()
+    };
+
     let title_bar: Element<Message> = row![
         mouse_area(
             container(components::title("Snapdash Settings", p))
@@ -140,11 +158,7 @@ pub fn view(snap: &Snapdash, id: iced::window::Id) -> Element<'_, Message> {
                 .padding([4, 0])
         )
         .on_press(Message::StartDrag(id)),
-        if snap.update_state == UpdateState::UpdateAvailable {
-            components::badge("Update Available", p)
-        } else {
-            iced::widget::space().width(0).height(0).into()
-        },
+        update_badge,
         components::icon("✕", p, Some(Message::CloseWindow(id))),
     ]
     .spacing(metric::GAP)

--- a/src/update.rs
+++ b/src/update.rs
@@ -4,8 +4,12 @@ pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct GitHubRelease {
-    tag_name: String,
-    // html_url: String,   //intentionaly left here for future useage.
+    pub tag_name: String,
+    #[serde(default)]
+    pub body: String,
+
+    #[serde(default)]
+    pub html_url: String, //intentionaly left here for future useage.
 }
 
 pub async fn get_latest_version() -> Option<GitHubRelease> {


### PR DESCRIPTION
Clicking the update-available indicator (or the "Update Available" badge) now opens a new window rendering the GitHub release body as markdown, with version-delta info and an "Open on GitHub" action that launches the release page in the default browser.

Changes:
- update.rs: capture `body` and `html_url` from GitHub's release API
- app.rs: new WindowKind::ReleaseNotes + latest_release state; parse markdown once on LastVersionChecked for render-time borrowing
- ui/release_notes.rs: new view, themed via components + iced::themer to honor MacLight/MacDark; custom markdown Style with palette-tuned inline code + link colors; compact typography (13px base)
- ui/settings.rs: swap update-indicator glyph `⟳` → `⤓`; make icon + badge clickable when UpdateAvailable
- ui/components.rs: add `scrollable` helper for themed scrollbars; refactor two duplicate inline styling blocks in sensor sections to use the shared helper
- Cargo.toml: enable iced `markdown` feature, add `open = "5"`