### PR TITLE
fix(ui): conditionally render gear overlay instead of alpha modulation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -603,6 +603,7 @@ impl Snapdash {
             Message::QuitApp => iced::exit(),
 
             Message::EntityHover { window, on } => {
+                tracing::debug!(?window, on, "cursor hover changed");
                 if let Some(w) = self.windows.get_mut(&window) {
                     w.entity.hovered = on;
                 }

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -33,21 +33,27 @@ pub fn with_gear_overlay<'a>(
     inner: Element<'a, Message>,
     win: &WindowState,
 ) -> Element<'a, Message> {
+    // Conditional rendering: when not hovered, gear is not part of the
+    // widget tree at all. Avoids relying on alpha-0 transparency, which
+    // doesn't actually hide the widget on Windows wgpu pipeline (state +
+    // re-render are correct, alpha=0.0 reaches the renderer, but the
+    // glyph still rasterizes visibly — likely a blend-mode quirk for
+    // text-on-transparent-surface).
+
+    if !win.entity.hovered {
+        return inner;
+    }
+
     let ui_theme = UiTheme::from(&app.theme);
-    let a = if win.entity.hovered { 1.0 } else { 0.0 };
 
     let gear_icon = iced::widget::text("⚙")
         .size(28)
-        .style(icon_text(ui_theme, a));
+        .style(icon_text(ui_theme, 1.0));
 
     let gear_button = iced::widget::button(gear_icon)
         .padding(8)
-        .on_press_maybe(if a > 0.0 {
-            Some(Message::OpenSettings)
-        } else {
-            None
-        })
-        .style(icon_button(ui_theme, a));
+        .on_press(Message::OpenSettings)
+        .style(icon_button(ui_theme, 1.0));
 
     let gear_layer: Element<Message> = iced::widget::container(gear_button)
         .width(Length::Fill)


### PR DESCRIPTION
On Windows, alpha=0.0 on the gear text/button reaches the renderer correctly (verified via trace logs: state and render calls fire as expected), but the iced wgpu pipeline doesn't actually clear the glyph — the gear stays visually present despite alpha=0. This is a blend-mode quirk for text-on-transparent-surface specific to the Windows backend.

Sidestep by toggling the gear's presence in the widget tree itself: when entity.hovered is false, return the inner content unchanged (no stack layer added). When true, build the gear layer with alpha=1.

Render diff: cached top-of-stack layer is invalidated on tree change, so the gear correctly disappears on next frame. Linux/macOS behave identically — they were already correct under alpha=0, and remain correct under conditional rendering.

mouse_area on_enter/on_exit and the surrounding hover-detection machinery are unchanged — events were always being delivered correctly; only the visual response was broken.
