### PR TITLE
refactor(ui): drop diagnostics overlay and rename macos.rs to native_shadows.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,7 +1641,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p7#32b872394d8995b6febcc078c78bf403fc805641"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p10#c6a9162ea4e1a8d48ac4b890d67314049333b869"
 dependencies = [
  "iced_core",
  "iced_debug",
@@ -1656,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p7#32b872394d8995b6febcc078c78bf403fc805641"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p10#c6a9162ea4e1a8d48ac4b890d67314049333b869"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p7#32b872394d8995b6febcc078c78bf403fc805641"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p10#c6a9162ea4e1a8d48ac4b890d67314049333b869"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1683,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p7#32b872394d8995b6febcc078c78bf403fc805641"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p10#c6a9162ea4e1a8d48ac4b890d67314049333b869"
 dependencies = [
  "futures",
  "iced_core",
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p7#32b872394d8995b6febcc078c78bf403fc805641"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p10#c6a9162ea4e1a8d48ac4b890d67314049333b869"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
@@ -1715,7 +1715,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p7#32b872394d8995b6febcc078c78bf403fc805641"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p10#c6a9162ea4e1a8d48ac4b890d67314049333b869"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -1724,7 +1724,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p7#32b872394d8995b6febcc078c78bf403fc805641"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p10#c6a9162ea4e1a8d48ac4b890d67314049333b869"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -1736,7 +1736,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p7#32b872394d8995b6febcc078c78bf403fc805641"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p10#c6a9162ea4e1a8d48ac4b890d67314049333b869"
 dependencies = [
  "bytes",
  "iced_core",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p7#32b872394d8995b6febcc078c78bf403fc805641"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p10#c6a9162ea4e1a8d48ac4b890d67314049333b869"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -1764,7 +1764,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p7#32b872394d8995b6febcc078c78bf403fc805641"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p10#c6a9162ea4e1a8d48ac4b890d67314049333b869"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
@@ -1783,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p7#32b872394d8995b6febcc078c78bf403fc805641"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p10#c6a9162ea4e1a8d48ac4b890d67314049333b869"
 dependencies = [
  "iced_renderer",
  "log",
@@ -1797,7 +1797,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0"
-source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p7#32b872394d8995b6febcc078c78bf403fc805641"
+source = "git+https://github.com/schizza/iced.git?tag=snapdash-v0.14.0-p10#c6a9162ea4e1a8d48ac4b890d67314049333b869"
 dependencies = [
  "iced_debug",
  "iced_program",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,13 +75,13 @@ keyring = { version = "3.6.3", features = [
 ] }
 
 [patch.crates-io]
-iced = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p7" }
-iced_winit = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p7" }
-iced_runtime = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p7" }
-iced_program = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p7" }
-iced_renderer = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p7" }
-iced_widget = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p7" }
-iced_core = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p7" }
+iced = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p10" }
+iced_winit = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p10" }
+iced_runtime = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p10" }
+iced_program = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p10" }
+iced_renderer = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p10" }
+iced_widget = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p10" }
+iced_core = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p10" }
 
 [profile.release]
 opt-level = "z"

--- a/src/app.rs
+++ b/src/app.rs
@@ -224,12 +224,18 @@ impl Snapdash {
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        let redraw_events = iced::event::listen_raw(|event, _status, id| match event {
-            iced::Event::Window(window::Event::RedrawRequested(_)) => {
-                Some(Message::WindowRedraw(id))
-            }
-            _ => None,
-        });
+        let redraw_events_needed = self.windows.values().any(|win| win.entity.pulse > 0.0);
+
+        let redraw_events = if redraw_events_needed {
+            iced::event::listen_raw(|event, _status, id| match event {
+                iced::Event::Window(window::Event::RedrawRequested(_)) => {
+                    Some(Message::WindowRedraw(id))
+                }
+                _ => None,
+            })
+        } else {
+            Subscription::none()
+        };
 
         let ha = if let Some(connection) = &self.ha_connection {
             Subscription::run_with(connection.clone(), crate::ha::ws::connect).map(Message::HaEvent)

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use crate::logger::LogType;
 use crate::ui::platform::window_settings;
 use crate::update;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use iced::{Element, Task};
 use iced::{Subscription, window};
@@ -23,7 +23,6 @@ pub enum WindowKind {
 pub struct WindowState {
     pub kind: WindowKind,
     pub entity: EntityWindowState,
-    pub debug: WindowDebugState,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -32,40 +31,6 @@ pub struct EntityWindowState {
     pub last: Option<EntityState>,
     pub pulse: f32, // TODO: Replace with Animation/spring. Currently just easy "animation paramter" (0..1), později nahradit Animation/spring
     pub hovered: bool,
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct WindowDebugState {
-    pub redraw_total: u64,
-    pub redraws_last_second: usize,
-    pub last_redraw_at: Option<Instant>,
-    pub last_redraw_delta_ms: Option<f32>,
-    recent_redraws: VecDeque<Instant>,
-}
-
-impl WindowDebugState {
-    fn record_redraw(&mut self, now: Instant) {
-        if let Some(previous) = self.last_redraw_at {
-            self.last_redraw_delta_ms =
-                Some(now.saturating_duration_since(previous).as_secs_f32() * 1000.0);
-        }
-
-        self.last_redraw_at = Some(now);
-        self.redraw_total = self.redraw_total.saturating_add(1);
-        self.recent_redraws.push_back(now);
-        self.prune(now);
-    }
-
-    fn prune(&mut self, now: Instant) {
-        while matches!(
-            self.recent_redraws.front(),
-            Some(at) if now.saturating_duration_since(*at) > Duration::from_secs(1)
-        ) {
-            self.recent_redraws.pop_front();
-        }
-
-        self.redraws_last_second = self.recent_redraws.len();
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -112,7 +77,6 @@ pub struct Snapdash {
     pub active_settings_sensors: Vec<SettingsSensor>,
 
     pub entity_search_query: String,
-    pub debug_now: Instant,
 
     pub update_state: UpdateState,
     pub latest_release: Option<update::GitHubRelease>,
@@ -135,8 +99,6 @@ pub enum Message {
     ThemeSelected(ThemeKind),
     SaveConfig,
     ToggleWidget(String),
-    #[cfg(feature = "diagnostics")]
-    DebugOverlayToggled(bool),
 
     // Home Assistant
     ConnectHa,
@@ -152,7 +114,7 @@ pub enum Message {
     SavePressed,
     Saved,
     HaTokenDraftChanged(String),
-    WindowRedraw(window::Id, Instant),
+    WindowRedraw(window::Id),
     ConfigLoad(Result<Config, String>),
     StartDrag(window::Id),
     EntityHover {
@@ -190,7 +152,6 @@ impl Snapdash {
             selected_widgets: HashSet::new(),
             active_settings_sensors: Vec::new(),
             entity_search_query: String::new(),
-            debug_now: Instant::now(),
             update_state: UpdateState::Unknown,
             latest_release: None,
             release_notes_items: Vec::new(),
@@ -263,28 +224,12 @@ impl Snapdash {
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        let redraw_events_needed = {
-            #[cfg(feature = "diagnostics")]
-            {
-                self.config.debug_overlay || self.windows.values().any(|win| win.entity.pulse > 0.0)
+        let redraw_events = iced::event::listen_raw(|event, _status, id| match event {
+            iced::Event::Window(window::Event::RedrawRequested(_)) => {
+                Some(Message::WindowRedraw(id))
             }
-
-            #[cfg(not(feature = "diagnostics"))]
-            {
-                self.windows.values().any(|win| win.entity.pulse > 0.0)
-            }
-        };
-
-        let redraw_events = if redraw_events_needed {
-            iced::event::listen_raw(|event, _status, id| match event {
-                iced::Event::Window(window::Event::RedrawRequested(now)) => {
-                    Some(Message::WindowRedraw(id, now))
-                }
-                _ => None,
-            })
-        } else {
-            Subscription::none()
-        };
+            _ => None,
+        });
 
         let ha = if let Some(connection) = &self.ha_connection {
             Subscription::run_with(connection.clone(), crate::ha::ws::connect).map(Message::HaEvent)
@@ -326,39 +271,15 @@ impl Snapdash {
         ])
     }
 
-    fn handle_redraw_requested(&mut self, id: window::Id, now: Instant) {
-        self.debug_now = now;
-
+    fn handle_redraw_requested(&mut self, id: window::Id) {
         let Some(window) = self.windows.get_mut(&id) else {
             return;
         };
-
-        window.debug.record_redraw(now);
 
         if let WindowKind::Entity { .. } = window.kind
             && window.entity.pulse > 0.0
         {
             window.entity.pulse = (window.entity.pulse - 0.08).max(0.0);
-        }
-    }
-
-    #[cfg(feature = "diagnostics")]
-    fn seed_debug_overlay(&mut self, now: Instant) {
-        self.debug_now = now;
-
-        for window in self.windows.values_mut() {
-            // Treat enabling diagnostics as the first visible redraw so static
-            // windows do not stay stuck at zero until some unrelated repaint.
-            window.debug.record_redraw(now);
-        }
-    }
-
-    #[cfg(feature = "diagnostics")]
-    fn seed_debug_window(&mut self, id: window::Id, now: Instant) {
-        self.debug_now = now;
-
-        if let Some(window) = self.windows.get_mut(&id) {
-            window.debug.record_redraw(now);
         }
     }
 
@@ -531,19 +452,6 @@ impl Snapdash {
                 Task::none()
             }
 
-            #[cfg(feature = "diagnostics")]
-            Message::DebugOverlayToggled(enabled) => {
-                self.config.debug_overlay = enabled;
-                if enabled {
-                    self.seed_debug_overlay(Instant::now());
-                }
-                let cfg = self.config.clone();
-
-                Task::perform(async move { cfg.save_async().await }, |_| {
-                    Message::SaveConfig
-                })
-            }
-
             Message::HaTokenDelete => {
                 match secrets::delete_ha_token() {
                     Ok(_) => {
@@ -604,7 +512,6 @@ impl Snapdash {
             Message::QuitApp => iced::exit(),
 
             Message::EntityHover { window, on } => {
-                tracing::debug!(?window, on, "cursor hover changed");
                 if let Some(w) = self.windows.get_mut(&window) {
                     w.entity.hovered = on;
                 }
@@ -653,18 +560,7 @@ impl Snapdash {
                         }
                         self.entity_windows.insert(entity_id.clone(), id);
                     }
-                    self.windows.insert(
-                        id,
-                        WindowState {
-                            kind,
-                            entity,
-                            debug: WindowDebugState::default(),
-                        },
-                    );
-                    #[cfg(feature = "diagnostics")]
-                    if self.config.debug_overlay {
-                        self.seed_debug_window(id, Instant::now());
-                    }
+                    self.windows.insert(id, WindowState { kind, entity });
                 } else {
                     self.set_status(
                         "Received WindowActuallyOpened but pending_opens is empty",
@@ -777,9 +673,11 @@ impl Snapdash {
                 self.theme = t;
                 self.config.theme = t;
                 let cfg = self.config.clone();
-                Task::perform(async move { cfg.save_async().await }, |_| {
+                let save = Task::perform(async move { cfg.save_async().await }, |_| {
                     Message::SaveConfig
-                })
+                });
+
+                Task::batch([save])
             }
 
             Message::SaveConfig => Task::none(),
@@ -845,8 +743,8 @@ impl Snapdash {
                 }
             }
 
-            Message::WindowRedraw(id, now) => {
-                self.handle_redraw_requested(id, now);
+            Message::WindowRedraw(id) => {
+                self.handle_redraw_requested(id);
                 Task::none()
             }
 
@@ -894,7 +792,6 @@ impl Snapdash {
         };
 
         let inner = crate::ui::chrome::window_content(self, win, id);
-        let inner = crate::ui::chrome::with_debug_overlay(self, inner, win);
 
         let inner = match win.kind {
             WindowKind::Entity { .. } => {
@@ -908,7 +805,7 @@ impl Snapdash {
         // Platform-specific outer wrapping:
         // - Linux: transparent `SHADOW_MARGIN` padding around the card so
         //   the iced-wgpu shader shadow has room to fade inside the surface.
-        // - macOS/Windows: pass-through. The OS hack in iced_winit clips the
+        // - macOS/Windows: pass-through. Platform-specific window settings clip the
         //   window to a rounded shape and the OS draws the drop shadow.
         crate::ui::platform::wrap_outer(inner)
     }
@@ -918,10 +815,10 @@ impl Snapdash {
     /// (the default theme background would show as an opaque color there).
     ///
     /// On macOS/Windows we intentionally do NOT install this callback (see
-    /// `main.rs`) — the OS hack clips the window to a rounded shape before
-    /// any cleared pixel is visible, so the default opaque theme background
-    /// is never seen and matches the pre-shadow-margin behavior users
-    /// reported looked "nice and optimal".
+    /// `main.rs`) — the OS-level rounded-corner/shadow path clips the window to
+    /// a rounded shape before any cleared pixel is visible, so the default
+    /// opaque theme background is never seen and matches the pre-shadow-margin
+    /// behavior users reported looked "nice and optimal".
     #[cfg(target_os = "linux")]
     pub fn style(&self, _theme: &iced::Theme) -> iced::theme::Style {
         iced::theme::Style {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,11 @@ use iced::daemon;
 
 /// Build and run the Snapdash daemon.
 ///
-/// On Linux and Windows we install a custom `.style()` that clears the
-/// surface to `Color::TRANSPARENT` so the shadow-margin area around the
-/// card stays transparent (see `Snapdash::style` and `ui::platform`).
-/// On macOS the OS-level rounded-corner hack in iced_winit plus the
-/// card-filling-the-window layout make the default opaque theme clear
-/// color invisible, so we keep the iced default.
+/// On Linux we install a custom `.style()` that clears the surface to
+/// `Color::TRANSPARENT` so the shadow-margin area around the card stays
+/// transparent (see `Snapdash::style` and `ui::platform`). On macOS/Windows
+/// the native rounded-corner/shadow path clips the card-filling window before
+/// any cleared pixel is visible, so we keep the iced default.
 pub fn run() -> iced::Result {
     let _gurad = logger::init();
 

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -1,10 +1,7 @@
 use iced::widget::{MouseArea, mouse_area};
-#[cfg(feature = "diagnostics")]
-use iced::widget::{column, container, text};
+
 use iced::window;
 use iced::{Alignment, Element, Length};
-#[cfg(feature = "diagnostics")]
-use iced::{Background, Border};
 
 use crate::app::{Message, UpdateState, WindowKind, WindowState};
 use crate::ui::theme::{UiTheme, icon_button, icon_text};
@@ -64,87 +61,6 @@ pub fn with_gear_overlay<'a>(
         .into();
 
     iced::widget::stack![inner, gear_layer].into()
-}
-
-#[cfg(feature = "diagnostics")]
-pub fn with_debug_overlay<'a>(
-    app: &crate::app::Snapdash,
-    inner: Element<'a, Message>,
-    win: &WindowState,
-) -> Element<'a, Message> {
-    if !app.config.debug_overlay {
-        return inner;
-    }
-    let p = app.theme.palette();
-    let last_delta = win
-        .debug
-        .last_redraw_delta_ms
-        .map(|ms| format!("{ms:.1} ms"))
-        .unwrap_or_else(|| "-".into());
-
-    let overlay_card: Element<Message> = container(
-        column![
-            text("debug")
-                .size(11)
-                .style(move |_: &iced::Theme| iced::widget::text::Style {
-                    color: Some(p.text_dim),
-                }),
-            text(format!("fps ~ {}", win.debug.redraws_last_second))
-                .size(12)
-                .style(move |_: &iced::Theme| iced::widget::text::Style {
-                    color: Some(p.text_primary),
-                },),
-            text(format!("redraws {}", win.debug.redraw_total))
-                .size(12)
-                .style(move |_: &iced::Theme| iced::widget::text::Style {
-                    color: Some(p.text_primary),
-                },),
-            text(format!("last delta {last_delta}"))
-                .size(12)
-                .style(move |_: &iced::Theme| iced::widget::text::Style {
-                    color: Some(p.text_primary),
-                },),
-            text("since last live off")
-                .size(12)
-                .style(move |_: &iced::Theme| iced::widget::text::Style {
-                    color: Some(p.text_primary),
-                },),
-        ]
-        .spacing(2),
-    )
-    .padding([8, 10])
-    .style(move |_| container::Style {
-        background: Some(Background::Color(iced::Color {
-            a: 0.88,
-            ..p.card_2
-        })),
-        border: Border {
-            radius: 12.0.into(),
-            width: 1.0,
-            color: p.border,
-        },
-        ..Default::default()
-    })
-    .into();
-
-    let overlay_layer: Element<Message> = container(overlay_card)
-        .width(Length::Fill)
-        .height(Length::Fill)
-        .align_x(Alignment::Start)
-        .align_y(Alignment::Start)
-        .padding(10)
-        .into();
-
-    iced::widget::stack![inner, overlay_layer].into()
-}
-
-#[cfg(not(feature = "diagnostics"))]
-pub fn with_debug_overlay<'a>(
-    _app: &crate::app::Snapdash,
-    inner: Element<'a, Message>,
-    _win: &WindowState,
-) -> Element<'a, Message> {
-    inner
 }
 
 /// Wraps `MouseArea` with hover effect and added drag.

--- a/src/ui/platform/composited.rs
+++ b/src/ui/platform/composited.rs
@@ -1,9 +1,8 @@
-//! Composited shadow rendering for Linux + Windows.
+//! Composited shadow rendering for Linux.
 //!
-//! Both platforms render their own anti-aliased rounded corners + drop
-//! shadow inside the window via the iced-wgpu shader, since the OS-level
-//! mechanisms either don't exist (Linux compositors) or produce jagged
-//! 1-bit results (Windows `SetWindowRgn`).
+//! Linux renders its own anti-aliased rounded corners + drop shadow inside
+//! the window via the iced-wgpu shader, since desktop compositors do not draw
+//! native shadows for undecorated transparent surfaces.
 //!
 //! See `super` module doc for the high-level approach.
 

--- a/src/ui/platform/mod.rs
+++ b/src/ui/platform/mod.rs
@@ -2,27 +2,24 @@
 //!
 //! Different OSes handle transparent frameless windows differently:
 //!
-//! - **macOS**: OS-level hacks in iced_winit (`CALayer.cornerRadius +
-//!   masksToBounds`, `SetWindowRgn`) clip the window to a rounded shape, and
-//!   the platform's WindowServer/DWM renders its own native drop shadow around
-//!   that shape. The card fills the window edge-to-edge. The iced-side shader
-//!   shadow is effectively invisible (it has nowhere to render since the card
-//!   covers everything). Clear color can stay at the theme default.
+//! - **macOS and Windows**: iced_winit/platform settings clip the window to a
+//!   rounded shape and the platform compositor renders its native drop shadow
+//!   around that shape. The card fills the window edge-to-edge. The iced-side
+//!   shader shadow is effectively invisible (it has nowhere to render since the
+//!   card covers everything). Clear color can stay at the theme default.
 //!
-//! - **Linux (X11 / Wayland) and Windows**: There's no OS-level rounding
-//!   that yields anti-aliased edges + shadow for an undecorated transparent
-//!   window. Linux compositors won't draw shadows for borderless surfaces;
-//!   Windows uses `SetWindowRgn` which produces 1-bit jagged ("cranky")
-//!   masks and no DWM shadow. Both platforms instead rely on:
+//! - **Linux (X11 / Wayland)**: There's no OS-level rounding that yields
+//!   anti-aliased edges + shadow for an undecorated transparent window. Linux
+//!   compositors won't draw shadows for borderless surfaces, so we rely on:
 //!     1. Window surface enlarged by [`SHADOW_MARGIN`] on every side.
 //!     2. Visible content wrapped in a transparent padding of the same width.
 //!     3. `Snapdash::style` clearing the surface to `Color::TRANSPARENT`.
 //!     4. The iced wgpu shader rendering anti-aliased rounded corners +
 //!        drop shadow into the margin, blended onto the desktop by the
-//!        compositor / DWM.
+//!        compositor.
 //!
 //!   This is how GTK4/libadwaita apps draw their own shadow on Linux, and
-//!   the same approach works on Windows for an identical look.
+//!   keeps us away from 1-bit XShape corners when a compositor is present.
 //!
 //! Both branches expose the same small API ([`window_size`], [`wrap_outer`])
 //! so `app.rs` stays platform-agnostic at the call sites.
@@ -33,6 +30,6 @@ mod composited;
 pub use composited::*;
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-mod macos;
+mod native_shadow;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
-pub use macos::*;
+pub use native_shadow::*;

--- a/src/ui/platform/native_shadow.rs
+++ b/src/ui/platform/native_shadow.rs
@@ -1,10 +1,10 @@
-//! macOS platform bits. See `super` module doc for the big picture.
+//! Native platform shadow rendering for macOS + Windows.
 //!
-//! macOS uses an iced_winit hack (`CALayer.cornerRadius +
-//! masksToBounds`) to clip the window surface to a rounded rectangle,
-//! with WindowServer rendering a platform-native drop shadow around the
-//! clipped region. The card fills the window edge-to-edge and the iced
-//! shader shadow is not used.
+//! macOS uses an iced_winit layer setup (`CALayer.cornerRadius + masksToBounds`)
+//! and Windows uses DWM corner/shadow settings. In both cases the OS clips the
+//! surface to a rounded rectangle and renders a platform-native drop shadow
+//! around the clipped region. The card fills the window edge-to-edge and the
+//! iced shader shadow is not used.
 //!
 //! Helpers here are therefore pass-throughs that keep `app.rs` tidy.
 
@@ -15,8 +15,8 @@ use crate::app::Message;
 
 /// Window surface size for a given card size.
 ///
-/// On macOS the surface is exactly the card size — the OS clips the
-/// outer edge to a rounded shape and provides the drop shadow itself.
+/// The surface is exactly the card size — the OS clips the outer edge to a
+/// rounded shape and provides the drop shadow itself.
 pub fn window_size(card_width: f32, card_height: f32) -> iced::Size {
     iced::Size::new(card_width, card_height)
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "diagnostics")]
-use iced::widget::checkbox;
 use iced::widget::{column, container, mouse_area, row};
 use iced::{Element, Length, mouse};
 
@@ -186,41 +184,6 @@ pub fn view(snap: &Snapdash, id: iced::window::Id) -> Element<'_, Message> {
         .height(Length::Fill)
         .push(home_assistant_card)
         .push(theme_card);
-
-    #[cfg(feature = "diagnostics")]
-    {
-        let debug_toggle: Element<Message> = checkbox(snap.config.debug_overlay)
-            .label("Show debug overlay in windows")
-            .on_toggle(Message::DebugOverlayToggled)
-            .text_size(14)
-            .style(move |_, _| iced::widget::checkbox::Style {
-                background: iced::Background::Color(p.bg),
-                text_color: Some(p.text_primary),
-                icon_color: p.accent,
-                border: iced::Border {
-                    color: p.text_primary,
-                    width: 0.5,
-                    radius: 15.0.into(),
-                },
-            })
-            .into();
-
-        let diagnostics_card = components::subcard(
-            column![
-                components::section("Diagnostics", p),
-                debug_toggle,
-                components::dimmed(
-                    "FPS is derived from real iced redraw events after diagnostics are enabled.",
-                    p
-                ),
-            ]
-            .spacing(metric::GAP)
-            .into(),
-            p,
-        );
-
-        content = content.push(diagnostics_card);
-    }
 
     content = content.push(sensors_card).push(save_row).push(status_row);
 


### PR DESCRIPTION
The Windows multi-window redraw freeze is now fixed at the iced layer (RDW_INVALIDATE+RDW_UPDATENOW path with DwmFlush plus sibling re-present on each redraw, see iced fork snapdash-v0.14.0-p9), so the snapdash-side diagnostic scaffolding is no longer pulling its weight.

- Remove WindowDebugState, debug_overlay config, FPS overlay card, and the conditional redraw_events subscription. WindowRedraw drops the Instant payload it was only carrying for the overlay.
- Rename `ui/platform/macos.rs` to `native_shadow.rs` to match what it actually contains: macOS *and* Windows now share the OS-native rounded-corner + drop-shadow path. `composited.rs` is Linux-only.
- Repoint the iced patch to the local sibling checkout (../iced) for iteration; the p9 git tag entries stay commented in for the release flip.