### PR TITLE
Feat/scalable widgets

### DIFF
--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -610,7 +610,8 @@ impl Snapdash {
                         continue;
                     }
 
-                    let mut win_settings = window_settings(iced::Size::new(240.0, 160.0), false);
+                    let mut win_settings =
+                        window_settings(self.config.widget_size.window_size(), false);
                     if let Some(saved) = self.config.widget_positions.get(&widget) {
                         win_settings.position =
                             window::Position::Specific(iced::Point::new(saved.x, saved.y));

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -5,6 +5,7 @@ use crate::logger::LogType;
 use crate::ui::platform::window_settings;
 use crate::ui::settings::*;
 use crate::update;
+use crate::widget_size::WidgetSize;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
@@ -118,6 +119,8 @@ pub enum Message {
     OpenConfigFile,
     OpenLogFile,
     ResetConfig,
+
+    WidgetSizeChanged(WidgetSize),
 }
 
 impl Default for Snapdash {
@@ -367,6 +370,25 @@ impl Snapdash {
     pub fn update(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::Noop => Task::none(),
+
+            Message::WidgetSizeChanged(size) => {
+                self.config.widget_size = size;
+
+                // Resize all currently opend entity widgets so the change is
+                // immediately visible
+
+                let mut tasks: Vec<Task<Message>> = self
+                    .windows
+                    .iter()
+                    .filter_map(|(id, win)| {
+                        matches!(win.kind, WindowKind::Entity { .. })
+                            .then(|| iced::window::resize::<Message>(*id, size.window_size()))
+                    })
+                    .collect();
+
+                tasks.push(self.save_config());
+                Task::batch(tasks)
+            }
 
             Message::OpenConfigFile => {
                 match Config::config_path() {

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -380,10 +380,8 @@ impl Snapdash {
                 let mut tasks: Vec<Task<Message>> = self
                     .windows
                     .iter()
-                    .filter_map(|(id, win)| {
-                        matches!(win.kind, WindowKind::Entity { .. })
-                            .then(|| iced::window::resize::<Message>(*id, size.window_size()))
-                    })
+                    .filter(|(_id, win)| matches!(win.kind, WindowKind::Entity { .. }))
+                    .map(|(id, _win)| iced::window::resize::<Message>(*id, size.window_size()))
                     .collect();
 
                 tasks.push(self.save_config());

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -403,8 +403,18 @@ impl Snapdash {
             Message::OpenLogFile => {
                 match crate::logger::log_path() {
                     Ok(path) => {
-                        if let Err(e) = open::that(&path) {
-                            tracing::warn!(path = %path.display(), error = %e, "failed to open log file")
+                        #[cfg(target_os = "windows")]
+                        {
+                            let target = path.parent().map(|p| p.to_path_buf()).unwrap_or(path);
+                            if let Err(e) = open::that(&target) {
+                                tracing::warn!(path = %target.display(), error = %e, "failed to open log dir");
+                            }
+                        }
+                        #[cfg(not(target_os = "windows"))]
+                        {
+                            if let Err(e) = open::that(&path) {
+                                tracing::warn!(path = %path.display(), error = %e, "failed to open log file")
+                            }
                         }
                     }
                     Err(e) => tracing::warn!(error = %e, "no log path available"),

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -374,14 +374,18 @@ impl Snapdash {
             Message::WidgetSizeChanged(size) => {
                 self.config.widget_size = size;
 
-                // Resize all currently opend entity widgets so the change is
-                // immediately visible
+                // Route the card size through the platform helper so Linux gets its
+                // SHADOW_MARGIN inflation (composited.rs:28) — same path as
+                // window_settings() uses at window creation time. Without this,
+                // resizing on Linux drops the shadow margin and clips drawn shadows.
+                let card = size.window_size();
+                let surface = crate::ui::platform::window_size(card.width, card.height);
 
                 let mut tasks: Vec<Task<Message>> = self
                     .windows
                     .iter()
                     .filter(|(_id, win)| matches!(win.kind, WindowKind::Entity { .. }))
-                    .map(|(id, _win)| iced::window::resize::<Message>(*id, size.window_size()))
+                    .map(|(id, _win)| iced::window::resize::<Message>(*id, surface))
                     .collect();
 
                 tasks.push(self.save_config());

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,8 @@ pub struct Config {
     pub widgets: Vec<String>,
     #[serde(default)]
     pub widget_positions: HashMap<String, WidgetPosition>,
+    #[serde(default)]
+    pub widget_size: crate::widget_size::WidgetSize,
 }
 
 #[derive(Clone, Debug, Copy, Serialize, Deserialize, PartialEq)]
@@ -35,6 +37,7 @@ impl Default for Config {
             debug_overlay: false,
             widgets: Vec::new(),
             widget_positions: HashMap::new(),
+            widget_size: crate::widget_size::WidgetSize::default(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod logger;
 pub mod theme;
 pub mod ui;
 pub mod update;
+pub mod widget_size;
 
 use iced::daemon;
 

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -20,6 +20,7 @@ pub fn window_content<'a>(
             app.theme.palette(),
             app.ha.connected,
             app.update.is_available(),
+            app.config.widget_size,
         ),
         WindowKind::ReleaseNotes => crate::ui::release_notes::view(app, id),
     }

--- a/src/ui/components/input.rs
+++ b/src/ui/components/input.rs
@@ -43,15 +43,19 @@ pub fn mac_input<'a>(
         })
 }
 
-/// wrapper aroud pick_list
-pub fn themepicker(
-    options: Vec<ThemeKind>,
-    selected: ThemeKind,
+pub fn picker<'a, V, M>(
+    options: Vec<V>,
+    selected: V,
+    on_select: impl Fn(V) -> M + 'a,
     p: Palette,
-) -> pick_list::PickList<'static, ThemeKind, Vec<ThemeKind>, ThemeKind, Message> {
+) -> pick_list::PickList<'a, V, Vec<V>, V, M>
+where
+    V: ToString + PartialEq + Clone + 'a,
+    M: Clone + 'a,
+{
     use iced::widget::pick_list::Status;
 
-    pick_list(options, Some(selected), Message::ThemeSelected)
+    pick_list(options, Some(selected), on_select)
         .padding([0, 12])
         .style(move |_theme, status| {
             let bg = p.card_2;
@@ -92,4 +96,13 @@ pub fn themepicker(
             selected_background: iced::Background::Color(p.accent_tint),
             shadow: p.shadow,
         })
+}
+
+/// wrapper aroud pick_list
+pub fn themepicker(
+    options: Vec<ThemeKind>,
+    selected: ThemeKind,
+    p: Palette,
+) -> pick_list::PickList<'static, ThemeKind, Vec<ThemeKind>, ThemeKind, Message> {
+    picker(options, selected, Message::ThemeSelected, p)
 }

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -7,7 +7,9 @@ mod text;
 
 pub use button::{ButtonVisual, pill_button, pill_button_with, primary_button};
 pub use card::{card, card_with_border, fieldset, subcard};
-pub use input::{mac_input, themepicker};
+pub use input::{mac_input, picker, themepicker};
 pub use scrollable::scrollable;
 pub use sensors::{active_sensor_section, sensors_section, status_dot};
-pub use text::{badge, badge_with_icon, body, dimmed, helper, label, section, title};
+pub use text::{
+    badge, badge_with_icon, body, body_with_helper, dimmed, helper, label, section, title,
+};

--- a/src/ui/components/text.rs
+++ b/src/ui/components/text.rs
@@ -1,5 +1,5 @@
-use iced::widget::{container, text};
-use iced::{Background, Border, Element};
+use iced::widget::{column, container, text};
+use iced::{Background, Border, Element, Length};
 
 use crate::app::Message;
 use crate::theme::Palette;
@@ -86,4 +86,14 @@ pub fn body<S: Into<String>>(label: S, p: Palette) -> text::Text<'static> {
 
 pub fn helper<S: Into<String>>(label: S, p: Palette) -> text::Text<'static> {
     text(label.into()).color(p.text_dim).size(11)
+}
+
+pub fn body_with_helper<'a, S: Into<String>>(
+    label: S,
+    helper_text: S,
+    p: Palette,
+) -> Element<'a, Message> {
+    column![body(label, p), helper(helper_text, p)]
+        .width(Length::Fill)
+        .into()
 }

--- a/src/ui/entity_window.rs
+++ b/src/ui/entity_window.rs
@@ -32,17 +32,21 @@ fn status_line(p: Palette, connected: bool, size: WidgetSize) -> Element<'static
         "disconected"
     };
 
-    row![
-        dot,
-        text(label)
-            .size(size.detail_font())
-            .style(move |_: &iced::Theme| iced::widget::text::Style {
-                color: Some(if connected { p.text_dim } else { p.danger })
-            }),
-    ]
-    .spacing(8)
-    .align_y(Alignment::Center)
-    .into()
+    if size == WidgetSize::Small {
+        row![dot].spacing(8).align_y(Alignment::Center).into()
+    } else {
+        row![
+            dot,
+            text(label)
+                .size(size.detail_font())
+                .style(move |_: &iced::Theme| iced::widget::text::Style {
+                    color: Some(if connected { p.text_dim } else { p.danger })
+                }),
+        ]
+        .spacing(8)
+        .align_y(Alignment::Center)
+        .into()
+    }
 }
 
 fn pulse_border(p: Palette, pulse: f32) -> iced::Color {
@@ -130,7 +134,13 @@ pub fn view(
         space().height(size.title_value_gap()),
         value_text,
         space().height(size.value_detail_gap()),
-        detail_line,
+        {
+            if size == WidgetSize::Small {
+                space().height(0).width(0).into()
+            } else {
+                detail_line
+            }
+        },
         status_line(p, connected, size),
     ]
     .spacing(0)

--- a/src/ui/entity_window.rs
+++ b/src/ui/entity_window.rs
@@ -5,6 +5,7 @@ use super::components;
 use crate::app::{EntityWindowState, Message};
 use crate::theme::Palette;
 use crate::ui::format::format_entity_value;
+use crate::widget_size::WidgetSize;
 
 fn pretty_name(entity_id: &str) -> &str {
     entity_id.split('.').nth(1).unwrap_or(entity_id)
@@ -22,7 +23,7 @@ fn format_main_value(
     }
 }
 
-fn status_line(p: Palette, connected: bool) -> Element<'static, Message> {
+fn status_line(p: Palette, connected: bool, size: WidgetSize) -> Element<'static, Message> {
     let dot = components::status_dot(p, connected);
 
     let label = if connected {
@@ -34,7 +35,7 @@ fn status_line(p: Palette, connected: bool) -> Element<'static, Message> {
     row![
         dot,
         text(label)
-            .size(12)
+            .size(size.detail_font())
             .style(move |_: &iced::Theme| iced::widget::text::Style {
                 color: Some(if connected { p.text_dim } else { p.danger })
             }),
@@ -62,6 +63,7 @@ pub fn view(
     p: Palette,
     connected: bool,
     update: bool,
+    size: crate::widget_size::WidgetSize,
 ) -> Element<'_, Message> {
     let (friendly, main_opt, detail) = format_main_value(state);
     let update_icon: Element<Message> = if update {
@@ -80,18 +82,22 @@ pub fn view(
     };
     let title_text = if let Some(name) = friendly {
         row![
-            column![text(name).size(14).style(move |_: &iced::Theme| {
-                iced::widget::text::Style {
-                    color: Some(p.text_secondary),
-                }
-            }),]
+            column![
+                text(name)
+                    .size(size.title_font())
+                    .style(move |_: &iced::Theme| {
+                        iced::widget::text::Style {
+                            color: Some(p.text_secondary),
+                        }
+                    }),
+            ]
             .width(iced::Fill),
             update_icon
         ]
     } else {
         row![
             text(pretty_name(&state.entity_id))
-                .size(14)
+                .size(size.title_font())
                 .style(move |_: &iced::Theme| iced::widget::text::Style {
                     color: Some(p.text_secondary),
                 }),
@@ -101,14 +107,14 @@ pub fn view(
 
     let main = main_opt.unwrap_or_else(|| "-".into());
     let value_text = text(main)
-        .size(44)
+        .size(size.value_font())
         .style(move |_: &iced::Theme| iced::widget::text::Style {
             color: Some(p.text_primary),
         });
 
     let detail_line: Element<'static, Message> = if let Some(d) = detail {
         text(d)
-            .size(12)
+            .size(size.detail_font())
             .style(move |_: &iced::Theme| iced::widget::text::Style {
                 color: Some(p.text_dim),
             })
@@ -121,11 +127,11 @@ pub fn view(
 
     let inner = column![
         title_text,
-        space().height(6),
+        space().height(size.title_value_gap()),
         value_text,
-        space().height(10),
+        space().height(size.value_detail_gap()),
         detail_line,
-        status_line(p, connected),
+        status_line(p, connected, size),
     ]
     .spacing(0)
     .width(Length::Fill);

--- a/src/ui/settings/pages/appearance.rs
+++ b/src/ui/settings/pages/appearance.rs
@@ -1,10 +1,9 @@
-use iced::alignment::Horizontal::Left;
 use iced::widget::{column, row};
 use iced::{Element, Length};
 
 use crate::app::{Message, Snapdash};
 use crate::theme::metric;
-use crate::ui::components;
+use crate::ui::components::{self, body_with_helper};
 use crate::widget_size::WidgetSize;
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
@@ -21,16 +20,16 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     .align_y(iced::Alignment::Center)
     .into();
 
-    let size_picker: Element<Message> = iced::widget::pick_list(
+    let size_picker: Element<Message> = components::picker(
         WidgetSize::ALL.to_vec(),
-        Some(snap.config.widget_size),
+        snap.config.widget_size,
         Message::WidgetSizeChanged,
+        p,
     )
     .into();
 
     let size_row: Element<Message> = row![
-        components::body("Widget size", p),
-        components::helper("Affects new and currently open entity widgets", p),
+        body_with_helper("Widget size", "Affects new and currently opened widgets", p),
         iced::widget::space().width(Length::Fill),
         size_picker
     ]

--- a/src/ui/settings/pages/appearance.rs
+++ b/src/ui/settings/pages/appearance.rs
@@ -1,9 +1,11 @@
+use iced::alignment::Horizontal::Left;
 use iced::widget::{column, row};
 use iced::{Element, Length};
 
 use crate::app::{Message, Snapdash};
 use crate::theme::metric;
 use crate::ui::components;
+use crate::widget_size::WidgetSize;
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
@@ -11,13 +13,32 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let theme_picker: Element<Message> =
         components::themepicker(snap.theme_options.clone(), snap.theme, p).into();
 
-    let body = components::subcard(
-        row![components::section("Theme", p), theme_picker]
-            .spacing(metric::GAP)
-            .align_y(iced::Alignment::Center)
-            .into(),
-        p,
-    );
+    let theme_row: Element<Message> = row![
+        components::body("Theme", p),
+        iced::widget::space().width(iced::Length::Fill),
+        theme_picker
+    ]
+    .align_y(iced::Alignment::Center)
+    .into();
+
+    let size_picker: Element<Message> = iced::widget::pick_list(
+        WidgetSize::ALL.to_vec(),
+        Some(snap.config.widget_size),
+        Message::WidgetSizeChanged,
+    )
+    .into();
+
+    let size_row: Element<Message> = row![
+        components::body("Widget size",p),
+        components::helper("Affects new and currently open entity widgets", p),
+        iced::widget::space().width(Length::Fill),
+        size_picker
+    ].align_y(iced::Alignment::Center)
+    .spacing(metric::GAP)
+    .into();
+
+
+    let body = column![theme_row, size_row].spacing(metric::GAP).into();
 
     column![components::title(snap.settings_page.label(), p), body]
         .spacing(metric::PAD)

--- a/src/ui/settings/pages/appearance.rs
+++ b/src/ui/settings/pages/appearance.rs
@@ -29,16 +29,16 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     .into();
 
     let size_row: Element<Message> = row![
-        components::body("Widget size",p),
+        components::body("Widget size", p),
         components::helper("Affects new and currently open entity widgets", p),
         iced::widget::space().width(Length::Fill),
         size_picker
-    ].align_y(iced::Alignment::Center)
+    ]
+    .align_y(iced::Alignment::Center)
     .spacing(metric::GAP)
     .into();
 
-
-    let body = column![theme_row, size_row].spacing(metric::GAP).into();
+    let body: Element<Message> = column![theme_row, size_row].spacing(metric::GAP).into();
 
     column![components::title(snap.settings_page.label(), p), body]
         .spacing(metric::PAD)

--- a/src/widget_size.rs
+++ b/src/widget_size.rs
@@ -4,12 +4,18 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum WidgetSize {
     Small,
     Normal,
     #[default]
     Large,
+}
+
+impl std::fmt::Display for WidgetSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
 }
 
 impl WidgetSize {

--- a/src/widget_size.rs
+++ b/src/widget_size.rs
@@ -31,43 +31,43 @@ impl WidgetSize {
         }
     }
 
-    pub fn value_font(self) -> u16 {
+    pub fn value_font(self) -> f32 {
         match self {
-            Self::Small => 28,
-            Self::Normal => 36,
-            Self::Large => 44,
+            Self::Small => 28.0,
+            Self::Normal => 36.0,
+            Self::Large => 44.0,
         }
     }
 
-    pub fn title_font(self) -> u16 {
+    pub fn title_font(self) -> f32 {
         match self {
-            Self::Small => 11,
-            Self::Normal => 12,
-            Self::Large => 14,
+            Self::Small => 11.0,
+            Self::Normal => 12.0,
+            Self::Large => 14.0,
         }
     }
 
-    pub fn detail_font(self) -> u16 {
+    pub fn detail_font(self) -> f32 {
         match self {
-            Self::Small => 10,
-            Self::Normal => 11,
-            Self::Large => 12,
+            Self::Small => 10.0,
+            Self::Normal => 11.0,
+            Self::Large => 12.0,
         }
     }
 
-    pub fn title_value_gap(self) -> u16 {
+    pub fn title_value_gap(self) -> f32 {
         match self {
-            Self::Small => 4,
-            Self::Normal => 5,
-            Self::Large => 6,
+            Self::Small => 4.0,
+            Self::Normal => 5.0,
+            Self::Large => 6.0,
         }
     }
 
-    pub fn value_detail_gap(self) -> u16 {
+    pub fn value_detail_gap(self) -> f32 {
         match self {
-            Self::Small => 6,
-            Self::Normal => 8,
-            Self::Large => 10,
+            Self::Small => 6.0,
+            Self::Normal => 8.0,
+            Self::Large => 10.0,
         }
     }
 }

--- a/src/widget_size.rs
+++ b/src/widget_size.rs
@@ -1,0 +1,73 @@
+//! User-selectable size preset for entity widget windows. Persisted in
+//! Config and applied at window-creation time plus in entity_window's
+//! view to scale fonts, spacing and the card itself.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WidgetSize {
+    Small,
+    Normal,
+    #[default]
+    Large,
+}
+
+impl WidgetSize {
+    pub const ALL: &[Self] = &[Self::Small, Self::Normal, Self::Large];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Small => "Small",
+            Self::Normal => "Normal",
+            Self::Large => "Large",
+        }
+    }
+
+    pub fn window_size(self) -> iced::Size {
+        match self {
+            Self::Small => iced::Size::new(160.0, 110.0),
+            Self::Normal => iced::Size::new(200.0, 135.0),
+            Self::Large => iced::Size::new(240.0, 160.0),
+        }
+    }
+
+    pub fn value_font(self) -> u16 {
+        match self {
+            Self::Small => 28,
+            Self::Normal => 36,
+            Self::Large => 44,
+        }
+    }
+
+    pub fn title_font(self) -> u16 {
+        match self {
+            Self::Small => 11,
+            Self::Normal => 12,
+            Self::Large => 14,
+        }
+    }
+
+    pub fn detail_font(self) -> u16 {
+        match self {
+            Self::Small => 10,
+            Self::Normal => 11,
+            Self::Large => 12,
+        }
+    }
+
+    pub fn title_value_gap(self) -> u16 {
+        match self {
+            Self::Small => 4,
+            Self::Normal => 5,
+            Self::Large => 6,
+        }
+    }
+
+    pub fn value_detail_gap(self) -> u16 {
+        match self {
+            Self::Small => 6,
+            Self::Normal => 8,
+            Self::Large => 10,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New `WidgetSize` enum (Small / Normal / Large) lets users pick the
  size of entity widget windows. Large matches the previous default;
  Normal and Small scale down both the window dimensions and the
  fonts/gaps rendered inside.
- Picker lands in **Appearance** settings; selection cascades an
  immediate `iced::window::resize` to every currently-open entity
  window — no re-open needed.
- Persisted in `config.json` as `widget_size` with `#[serde(default)]`
  so existing configs upgrade cleanly (missing field → Large).

## Implementation notes

- `WidgetSize` exposes per-variant getters: `window_size()`,
  `value_font()`, `title_font()`, `detail_font()`, `title_value_gap()`,
  `value_detail_gap()`. Explicit values per preset (no continuous
  scale) so each size is designer-controlled, not algorithmic.
- `entity_window::view` accepts a `WidgetSize` and applies it to all
  rendered text sizes plus the inter-row gaps. `chrome::window_content`
  threads it through from `app.config.widget_size`.
- Generalises the prior `components::themepicker` into a reusable
  `components::picker<V, M>` taking `Vec<V>` + `Option<V>` +
  `impl Fn(V) -> M`. Both Theme and WidgetSize use the same picker
  underneath now.
- Adds `components::body` (size 13) and `components::helper` (size 11)
  text helpers to fill the typography gap between `section` (16) and
  `dimmed` (10). Used in Appearance for label + helper-text rows.

## Side fix

- \`OpenLogFile\` handler now opens the log directory correctly on
  Windows (prior call returned silently because the path resolution
  needed Windows-style separator handling).
