### PR TITLE
feat: start at login (cross-platform autostart)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17918dba7ecf78b9a14507ec9f984e7977d13fad87dc86d61038980a45d128cf"
+dependencies = [
+ "dirs",
+ "os_info",
+ "smappservice-rs",
+ "thiserror 2.0.18",
+ "windows-registry",
+ "windows-result 0.4.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1013,15 @@ name = "directories"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
@@ -2717,6 +2740,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2907,7 +2942,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
 ]
 
@@ -3012,6 +3047,16 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3148,6 +3193,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-service-management"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b213642d6959cc6023ceb1217aa595eaaf09b8094ce95127c103cab611fe65e8"
+dependencies = [
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-security",
+]
+
+[[package]]
 name = "objc2-symbols"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3169,13 +3238,34 @@ dependencies = [
  "objc2-cloud-kit 0.2.2",
  "objc2-core-data 0.2.2",
  "objc2-core-image 0.2.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
  "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
- "objc2-user-notifications",
+ "objc2-user-notifications 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-location 0.3.2",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "objc2-user-notifications 0.3.2",
 ]
 
 [[package]]
@@ -3198,8 +3288,18 @@ dependencies = [
  "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3296,6 +3396,21 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.30.1",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4357,6 +4472,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smappservice-rs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52703b97a53101cf5d4580e0737aaa634ce1fdcfc123c16b2a9658e358013488"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-service-management",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "smithay-client-toolkit"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4433,6 +4560,7 @@ name = "snapdash"
 version = "0.0.5"
 dependencies = [
  "anyhow",
+ "auto-launch",
  "chrono",
  "directories",
  "flate2",
@@ -5903,6 +6031,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6205,7 +6344,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.2.2",
  "orbclient",
  "percent-encoding",
  "pin-project",
@@ -6477,7 +6616,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
- "nix",
+ "nix 0.29.0",
  "ordered-stream",
  "rand 0.8.6",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ diagnostics = []
 
 [dependencies]
 anyhow = "1.0.102"
+auto-launch = "0.6.0"
 chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
 iced = { version = "0.14.0", features = ["wgpu", "tokio", "markdown"] }
 directories = "6.0.0"

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -547,6 +547,7 @@ impl Snapdash {
                     Ok(cfg) => {
                         self.theme = cfg.theme;
                         self.config = cfg;
+                        crate::autostart::validate_state(self.config.autostart);
                         self.rebuild_selected_widgets();
                         self.set_status("Config loaded", LogType::Info);
 

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -125,6 +125,8 @@ pub enum Message {
     InstallUpdate,
     UpdateInstelled(Result<std::path::PathBuf, String>),
     RestartAfterUpdate(std::path::PathBuf),
+
+    AutostartChanged(bool),
 }
 
 impl Default for Snapdash {
@@ -375,6 +377,27 @@ impl Snapdash {
         match message {
             Message::Noop => Task::none(),
 
+            Message::AutostartChanged(want) => {
+                let previous = self.config.autostart;
+                self.config.autostart = want;
+
+                let result = if want {
+                    crate::autostart::enable()
+                } else {
+                    crate::autostart::disable()
+                };
+
+                if let Err(e) = result {
+                    self.config.autostart = previous;
+                    tracing::error!(error = %e, want, "autostart update failed");
+                    self.set_status(format!("Autostart change failed: {e}"), LogType::Error);
+                    return Task::none();
+                }
+
+                let action = if want { "enabled" } else { "disabled" };
+                self.set_status(format!("Autostart {action}"), LogType::Info);
+                self.save_config()
+            }
             Message::InstallUpdate => {
                 // Guard
                 if !matches!(

--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -1,0 +1,66 @@
+//! Cross-platform autostart preference wiring. Asks the OS to launch
+//! Snapdash at user login.
+//!
+//! - macOS: writes a LaunchAgent plist under ~/Library/LaunchAgents.
+//!   First registration may surface in System Settings → Login Items
+//!   pending user approval. After that the agent persists.
+//! - Linux: drops a `.desktop` file in ~/.config/autostart per the XDG
+//!   spec. Works on GNOME, KDE Plasma, XFCE, Cinnamon. Tiling WMs
+//!   (sway, i3) need a separate xdg-autostart-launcher to honour it.
+//! - Windows: writes a string value to
+//!   HKCU\Software\Microsoft\Windows\CurrentVersion\Run.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use auto_launch::AutoLaunchBuilder;
+
+const APP_NAME: &str = "snapdash";
+
+/// Builds an AutoLaunch handle for the running binary. Resolves the
+/// path that should be registered with the OS — the .app bundle on
+/// macOS when present, otherwise the raw binary.
+fn handle() -> Result<auto_launch::AutoLaunch> {
+    let app_path = registration_path()?;
+    let path_string = app_path
+        .to_str()
+        .with_context(|| format!("non-UTF8 app path: {}", app_path.display()))?;
+
+    AutoLaunchBuilder::new()
+        .set_app_name(APP_NAME)
+        .set_app_path(path_string)
+        .set_macos_launch_mode(auto_launch::MacOSLaunchMode::LaunchAgent)
+        .build()
+        .context("build AutoLaunch handler")
+}
+
+/// Path the OS should launch.
+///
+/// On macOS, if we're running from inside a `.app` bundle, register the
+/// bundle (so OS launches `open Snapdash.app` correctly). Otherwise
+/// (dev `cargo run`, sideloaded binary) register `current_exe()`.
+fn registration_path() -> Result<PathBuf> {
+    #[cfg(target_os = "macos")]
+    if let Some(bundle) = crate::update::installer::detect_app_bundle() {
+        return Ok(bundle);
+    }
+
+    std::env::current_exe().context("resolve current_exe")
+}
+
+pub fn enable() -> Result<()> {
+    handle()?.enable().context("enable autostart")
+}
+
+pub fn disable() -> Result<()> {
+    handle()?.disable().context("disable autostart")
+}
+
+/// Whether the OS currently has a registration for our app. Best-effort:
+/// any error from the OS layer (missing config dir, malformed plist)
+/// counts as "not enabled" so callers don't panic on edge cases.
+pub fn is_enabled() -> bool {
+    handle()
+        .and_then(|h| h.is_enabled().context("query OS"))
+        .unwrap_or(false)
+}

--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -64,3 +64,26 @@ pub fn is_enabled() -> bool {
         .and_then(|h| h.is_enabled().context("query OS"))
         .unwrap_or(false)
 }
+
+/// Reconciles the user's stored preference with the OS-level
+/// registration. Called once after config loads — if the user wants
+/// autostart but the OS has forgotten about us (manual deletion of the
+/// plist/.desktop, app moved between filesystems), re-register
+/// silently. Logs but doesn't fail boot on errors.
+pub fn validate_state(want_enabled: bool) {
+    let os_enabled = is_enabled();
+
+    if want_enabled && !os_enabled {
+        match enable() {
+            Ok(_) => tracing::info!("autostart re-registered after drift"),
+            Err(e) => tracing::warn!(error = %e, "autostart re-register failed"),
+        }
+    } else if !want_enabled && os_enabled {
+        // User stored "off" but OS still has us listed — cleanup so
+        // we don't silently autostart against the user's preference.
+        match disable() {
+            Ok(_) => tracing::info!("autostart cleared (config says off)"),
+            Err(e) => tracing::warn!(error = %e, "autostart clear failed"),
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     #[serde(default)]
     pub debug_overlay: bool,
     #[serde(default)]
+    pub autostart: bool,
+    #[serde(default)]
     pub widgets: Vec<String>,
     #[serde(default)]
     pub widget_positions: HashMap<String, WidgetPosition>,
@@ -34,6 +36,7 @@ impl Default for Config {
             ha_url: "http://localhost:8123".into(),
             theme: ThemeKind::default(),
             ha_token_present: false,
+            autostart: false,
             debug_overlay: false,
             widgets: Vec::new(),
             widget_positions: HashMap::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod autostart;
 pub mod config;
 pub mod ha;
 pub mod logger;

--- a/src/ui/components/input.rs
+++ b/src/ui/components/input.rs
@@ -106,3 +106,35 @@ pub fn themepicker(
 ) -> pick_list::PickList<'static, ThemeKind, Vec<ThemeKind>, ThemeKind, Message> {
     picker(options, selected, Message::ThemeSelected, p)
 }
+
+pub fn toggler<'a, F, M>(is_checked: bool, on_toggle: F, p: Palette) -> iced::widget::Toggler<'a, M>
+where
+    F: Fn(bool) -> M + 'a,
+    M: Clone + 'a,
+{
+    iced::widget::toggler(is_checked)
+        .on_toggle(on_toggle)
+        .size(20)
+        .style(move |_theme, status| {
+            use iced::widget::toggler::{Status, Style};
+
+            let active = matches!(status, Status::Active { is_toggled: true })
+                || matches!(status, Status::Hovered { is_toggled: true });
+
+            Style {
+                background: if active {
+                    p.accent_tint.into()
+                } else {
+                    p.card_2.into()
+                },
+                background_border_width: 1.0,
+                background_border_color: if active { p.accent } else { p.border },
+                foreground: p.accent.into(),
+                foreground_border_width: 0.0,
+                foreground_border_color: iced::Color::TRANSPARENT,
+                text_color: p.text_body.into(),
+                border_radius: Some(999.0.into()),
+                padding_ratio: 0.15,
+            }
+        })
+}

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -7,7 +7,7 @@ mod text;
 
 pub use button::{ButtonVisual, pill_button, pill_button_with, primary_button};
 pub use card::{card, card_with_border, fieldset, subcard};
-pub use input::{mac_input, picker, themepicker};
+pub use input::{mac_input, picker, themepicker, toggler};
 pub use scrollable::scrollable;
 pub use sensors::{active_sensor_section, sensors_section, status_dot};
 pub use text::{

--- a/src/ui/components/text.rs
+++ b/src/ui/components/text.rs
@@ -89,6 +89,7 @@ pub fn helper<S: Into<String>>(label: S, p: Palette) -> text::Text<'static> {
     text(label.into()).color(p.text_dim).size(11)
 }
 
+/// Returns `column![...]` as Element<Message>
 pub fn body_with_helper<'a, S: Into<String>>(
     label: S,
     helper_text: S,
@@ -96,6 +97,7 @@ pub fn body_with_helper<'a, S: Into<String>>(
 ) -> Element<'a, Message> {
     column![body(label, p), helper(helper_text, p)]
         .width(Length::Fill)
+        .spacing(2)
         .into()
 }
 

--- a/src/ui/settings/pages/general.rs
+++ b/src/ui/settings/pages/general.rs
@@ -68,6 +68,47 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
 
     let stats = components::subcard(column![ha_row, sensors_row].spacing(metric::GAP).into(), p);
 
+    let autostart_row: Element<Message> = row![
+        components::body_with_helper(
+            "Start at login",
+            "Launch Snapdash automatically when you log in your computer.",
+            p
+        ),
+        iced::widget::toggler(snap.config.autostart)
+            .on_toggle(Message::AutostartChanged)
+            .size(20)
+            .style(move |_theme, status| {
+                use iced::widget::toggler::{Status, Style};
+                let active = matches!(status, Status::Active { is_toggled: true })
+                    || matches!(status, Status::Hovered { is_toggled: true });
+                Style {
+                    background: if active {
+                        p.accent.into()
+                    } else {
+                        p.card_2.into()
+                    },
+                    background_border_width: 1.0,
+                    background_border_color: if active { p.accent } else { p.border },
+                    foreground: p.text_primary.into(),
+                    foreground_border_width: 0.0,
+                    foreground_border_color: iced::Color::TRANSPARENT,
+                    text_color: p.text_body.into(),
+                    border_radius: Some(999.0.into()),
+                    padding_ratio: 0.15,
+                }
+            }),
+    ]
+    .align_y(iced::Alignment::Center)
+    .spacing(metric::GAP)
+    .into();
+
+    let behavior = components::subcard(
+        column![components::section("Behavior", p), autostart_row,]
+            .spacing(metric::GAP)
+            .into(),
+        p,
+    );
+
     let actions = components::subcard(
         column![action_config, action_logs]
             .spacing(metric::GAP)
@@ -80,6 +121,7 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
         hero,
         iced::widget::space().height(metric::PAD),
         stats,
+        behavior,
         actions,
     ]
     .spacing(metric::PAD)

--- a/src/ui/settings/pages/general.rs
+++ b/src/ui/settings/pages/general.rs
@@ -68,46 +68,42 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
 
     let stats = components::subcard(column![ha_row, sensors_row].spacing(metric::GAP).into(), p);
 
+    let macos_hint: Option<Element<Message>> = if cfg!(target_os = "macos") && snap.config.autostart
+    {
+        Some(
+            components::helper(
+                "macOS may ask you to allow Snapdash in System Settings → \
+                         Login Items the first time. After approval, autostart \
+                         persists across reboots.",
+                p,
+            )
+            .into(),
+        )
+    } else {
+        None
+    };
+
     let autostart_row: Element<Message> = row![
         components::body_with_helper(
             "Start at login",
             "Launch Snapdash automatically when you log in your computer.",
             p
         ),
-        iced::widget::toggler(snap.config.autostart)
-            .on_toggle(Message::AutostartChanged)
-            .size(20)
-            .style(move |_theme, status| {
-                use iced::widget::toggler::{Status, Style};
-                let active = matches!(status, Status::Active { is_toggled: true })
-                    || matches!(status, Status::Hovered { is_toggled: true });
-                Style {
-                    background: if active {
-                        p.accent.into()
-                    } else {
-                        p.card_2.into()
-                    },
-                    background_border_width: 1.0,
-                    background_border_color: if active { p.accent } else { p.border },
-                    foreground: p.text_primary.into(),
-                    foreground_border_width: 0.0,
-                    foreground_border_color: iced::Color::TRANSPARENT,
-                    text_color: p.text_body.into(),
-                    border_radius: Some(999.0.into()),
-                    padding_ratio: 0.15,
-                }
-            }),
+        components::toggler(snap.config.autostart, Message::AutostartChanged, p),
     ]
     .align_y(iced::Alignment::Center)
     .spacing(metric::GAP)
     .into();
 
-    let behavior = components::subcard(
-        column![components::section("Behavior", p), autostart_row,]
-            .spacing(metric::GAP)
-            .into(),
-        p,
-    );
+    let mut behavior_inner =
+        iced::widget::column![components::section("Behavior", p), autostart_row]
+            .spacing(metric::GAP);
+
+    if let Some(hint) = macos_hint {
+        behavior_inner = behavior_inner.push(hint);
+    }
+
+    let behavior = components::subcard(behavior_inner.into(), p);
 
     let actions = components::subcard(
         column![action_config, action_logs]


### PR DESCRIPTION
## Summary

Adds a "Start at login" toggle to `Settings → General` that registers
Snapdash with the OS autostart mechanism per platform:

- **macOS:** LaunchAgent plist in `~/Library/LaunchAgents/`
- **Linux:** XDG `.desktop` file in `~/.config/autostart/`
- **Windows:** registry value under `HKCU\…\Run`

Wraps the `auto-launch` crate so the per-platform mechanics stay
encapsulated in `src/autostart.rs`.

## Behaviour

- Toggle dispatches `Message::AutostartChanged(bool)` which mutates
  config, writes to the OS, and persists. OS-write failures (sandbox,
  read-only home) revert the in-memory state so the toggler reflects
  reality.
- On boot, `validate_state()` reconciles `config.autostart` with
  whatever the OS currently has registered — re-registers if a manual
  cleanup wiped the LaunchAgent/`.desktop`/registry entry.
- macOS toggles ON show an inline hint about the System Settings →
  Login Items approval flow first-timers may need to click through.

## Notes

- For macOS dev builds (`cargo run` outside a `.app`), registration
  uses `current_exe()` so autostart still works during development.
  Inside a packaged `.app`, the bundle path is registered (so
  LaunchAgent invokes `open Snapdash.app` correctly).
- No code signing required — LaunchAgent path works for unsigned
  bundles.

## Dependencies

- `auto-launch = "0.5"` — cross-platform autostart wrapper