### PR TITLE
refactor(ui): typed text sizes and declarative settings builders

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -113,3 +113,11 @@ pub mod metric {
     pub const PAD: f32 = 14.0;
     pub const GAP: f32 = 12.0;
 }
+
+pub mod text_size {
+    pub const NORMAL: f32 = 13.0;
+    pub const SMALL: f32 = 11.0;
+    pub const XSMALL: f32 = 10.0;
+    pub const LARGE: f32 = 15.0;
+    pub const XLARGE: f32 = 22.0;
+}

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -5,7 +5,7 @@ use iced::{Alignment, Element, Length};
 
 use crate::app::{Message, WindowKind, WindowState};
 use crate::ui::icon::Icon;
-use crate::ui::theme::{UiTheme, icon_button};
+use crate::ui::theme::icon_button;
 
 /// Returns window content based on its kind (`Settings` / `Entity`).
 pub fn window_content<'a>(
@@ -43,12 +43,12 @@ pub fn with_gear_overlay<'a>(
         return inner;
     }
 
-    let ui_theme = UiTheme::from(&app.theme);
+    let p = app.theme.palette();
 
-    let gear_button = iced::widget::button(Icon::Gear.text(ui_theme))
+    let gear_button = iced::widget::button(Icon::Gear.text(p))
         .padding(8)
         .on_press(Message::OpenSettings)
-        .style(icon_button(ui_theme, 1.0));
+        .style(icon_button(p, 1.0));
 
     let gear_layer: Element<Message> = iced::widget::container(gear_button)
         .width(Length::Fill)

--- a/src/ui/components/button.rs
+++ b/src/ui/components/button.rs
@@ -1,6 +1,10 @@
+use iced::widget::text::IntoFragment;
 use iced::{Background, Element, Length, widget::container};
 
-use crate::{app::Message, theme::Palette};
+use crate::{
+    app::Message,
+    theme::{Palette, text_size},
+};
 
 #[derive(Clone, Copy)]
 pub struct ButtonVisual {
@@ -14,6 +18,12 @@ pub struct ButtonVisual {
     pub text: iced::Color,
     pub text_disabled: iced::Color,
     pub radius: f32,
+}
+
+pub enum ButtonType {
+    PILL,
+    PRIMARY,
+    DANGER,
 }
 
 impl ButtonVisual {
@@ -35,13 +45,37 @@ impl ButtonVisual {
     pub fn primary(p: Palette) -> Self {
         Self {
             bg: p.accent_tint,
-            bg_hovered: p.accent,
-            bg_pressed: p.accent,
+            bg_hovered: p.accent_tint,
+            bg_pressed: p.accent_tint,
             bg_disabled: p.accent_tint,
-            border: iced::Color::TRANSPARENT,
-            border_hovered: iced::Color::TRANSPARENT,
+            border: p.accent_tint,
+            border_hovered: p.accent_dim,
             border_width: 1.0,
             text: p.text_primary,
+            text_disabled: p.text_disabled,
+            radius: 999.0,
+        }
+    }
+
+    pub fn danger(p: Palette) -> Self {
+        Self {
+            bg: iced::Color {
+                a: 0.16,
+                ..p.danger
+            },
+            bg_hovered: iced::Color {
+                a: 0.24,
+                ..p.danger
+            },
+            bg_pressed: iced::Color {
+                a: 0.32,
+                ..p.danger
+            },
+            bg_disabled: p.card_2,
+            border: p.danger,
+            border_hovered: p.danger,
+            border_width: 1.0,
+            text: p.danger,
             text_disabled: p.text_disabled,
             radius: 999.0,
         }
@@ -77,6 +111,19 @@ impl ButtonVisual {
     }
 }
 
+fn button_content<'a>(content: impl Into<Element<'a, Message>>) -> Element<'a, Message> {
+    container(content)
+        .width(Length::Shrink)
+        .height(Length::Fill)
+        .center_x(Length::Shrink)
+        .center_y(Length::Fill)
+        .into()
+}
+
+fn text_content<'a>(label: impl IntoFragment<'a>) -> Element<'a, Message> {
+    iced::widget::text(label).size(text_size::NORMAL).into()
+}
+
 fn styled_button<'a>(
     content: impl Into<Element<'a, Message>>,
     visual: ButtonVisual,
@@ -108,24 +155,19 @@ fn styled_button<'a>(
                 } else {
                     visual.text
                 },
+
                 ..Default::default()
             }
         })
 }
 
 pub fn primary_button<'a>(
-    label: impl Into<Element<'a, Message>>,
+    label: impl IntoFragment<'a>,
     p: Palette,
     on_press: Option<Message>,
 ) -> iced::widget::Button<'a, Message> {
-    let content = container(label)
-        .width(Length::Shrink)
-        .height(Length::Fill)
-        .center_x(Length::Shrink)
-        .center_y(Length::Fill);
-
     let mut b = styled_button(
-        content,
+        button_content(text_content(label)),
         ButtonVisual::primary(p),
         [0, 12],
         Length::Fixed(36.0),
@@ -139,17 +181,16 @@ pub fn primary_button<'a>(
 }
 
 pub fn pill_button<'a>(
-    label: impl Into<Element<'a, Message>>,
+    label: impl IntoFragment<'a>,
     p: Palette,
     on_press: Option<Message>,
 ) -> iced::widget::Button<'a, Message> {
-    let content = container(label)
-        .width(Length::Shrink)
-        .height(Length::Fill)
-        .center_x(Length::Shrink)
-        .center_y(Length::Fill);
-
-    let mut b = styled_button(content, ButtonVisual::pill(p), [0, 12], Length::Fixed(36.0));
+    let mut b = styled_button(
+        button_content(text_content(label)),
+        ButtonVisual::pill(p),
+        [0, 12],
+        Length::Fixed(36.0),
+    );
 
     if let Some(msg) = on_press {
         b = b.on_press(msg);
@@ -162,13 +203,7 @@ pub fn pill_button_with<'a>(
     visual: ButtonVisual,
     on_press: Option<Message>,
 ) -> iced::widget::Button<'a, Message> {
-    let content = container(label)
-        .width(Length::Shrink)
-        .height(Length::Fill)
-        .center_x(Length::Shrink)
-        .center_y(Length::Fill);
-
-    let mut b = styled_button(content, visual, [0, 12], Length::Fixed(36.0));
+    let mut b = styled_button(button_content(label), visual, [0, 12], Length::Fixed(36.0));
 
     if let Some(msg) = on_press {
         b = b.on_press(msg);
@@ -176,52 +211,38 @@ pub fn pill_button_with<'a>(
     b
 }
 
-// pub fn icon(
-//     content: impl Into<Element<'static, Message>>,
-//     p: Palette,
-//     on_press: Option<Message>,
-// ) -> iced::widget::Button<'static, Message> {
-//     use iced::widget::button::Status;
+pub fn danger_button_with<'a>(
+    content: Element<'a, Message>,
+    p: Palette,
+    on_press: Option<Message>,
+) -> iced::widget::Button<'a, Message> {
+    let mut b = styled_button(
+        button_content(content),
+        ButtonVisual::danger(p),
+        [0, 12],
+        Length::Fixed(36.0),
+    );
 
-//     let mut b = button(content)
-//         .padding([0, 12])
-//         .height(36)
-//         .style(move |_theme, status| {
-//             let mut bg = p.card_2;
-//             let mut border = p.border;
+    if let Some(m) = on_press {
+        b = b.on_press(m);
+    };
+    b
+}
 
-//             match status {
-//                 Status::Hovered => {
-//                     bg = p.card;
-//                     border = p.border_hovered
-//                 }
-//                 Status::Pressed => bg = p.accent_tint,
-//                 Status::Disabled => {
-//                     bg = p.card_2;
-//                     border = p.border
-//                 }
-//                 Status::Active => {}
-//             }
+pub fn danger_button<'a>(
+    label: impl IntoFragment<'a>,
+    p: Palette,
+    on_press: Option<Message>,
+) -> iced::widget::Button<'a, Message> {
+    let mut b = styled_button(
+        button_content(text_content(label)),
+        ButtonVisual::danger(p),
+        [0, 12],
+        Length::Fixed(36.0),
+    );
 
-//             button::Style {
-//                 background: Some(Background::Color(bg)),
-//                 border: Border {
-//                     radius: 999.0.into(),
-//                     width: 1.0,
-//                     color: border,
-//                 },
-//                 text_color: if matches!(status, Status::Disabled) {
-//                     p.text_disabled
-//                 } else {
-//                     p.text_body
-//                 },
-//                 ..Default::default()
-//             }
-//         });
-
-//     if let Some(msg) = on_press {
-//         b = b.on_press(msg);
-//     }
-
-//     b
-// }
+    if let Some(msg) = on_press {
+        b = b.on_press(msg);
+    }
+    b
+}

--- a/src/ui/components/card.rs
+++ b/src/ui/components/card.rs
@@ -2,7 +2,7 @@ use iced::widget::{column, container, row, stack, text};
 use iced::{Background, Border, Element, Length};
 
 use crate::app::Message;
-use crate::theme::{Palette, metric};
+use crate::theme::{Palette, metric, text_size};
 
 pub fn card(content: Element<Message>, p: Palette) -> Element<Message> {
     container(content)
@@ -127,14 +127,14 @@ pub fn fieldset<'a>(
     content: Element<'a, Message>,
     p: Palette,
 ) -> Element<'a, Message> {
-    let legend_chip: Element<'a, Message> = container(text(legend).size(13).style(
+    let legend_chip: Element<'a, Message> = container(text(legend).size(text_size::SMALL).style(
         move |_: &iced::Theme| iced::widget::text::Style {
             color: Some(p.text_dim),
         },
     ))
     .padding([0, 8])
     .style(move |_: &iced::Theme| iced::widget::container::Style {
-        background: Some(Background::Color(p.card_2)),
+        background: Some(p.card_2.into()),
         ..Default::default()
     })
     .into();

--- a/src/ui/components/input.rs
+++ b/src/ui/components/input.rs
@@ -3,7 +3,7 @@ use iced::widget::{pick_list, text_input};
 use iced::{Background, Border};
 
 use crate::app::Message;
-use crate::theme::{Palette, ThemeKind, metric};
+use crate::theme::{Palette, ThemeKind, metric, text_size};
 
 /// text_input wrapper to sytle as mac input
 pub fn mac_input<'a>(
@@ -14,6 +14,7 @@ pub fn mac_input<'a>(
     use iced::widget::text_input::Status;
 
     text_input(placeholder, value)
+        .size(text_size::NORMAL)
         .padding(10)
         .style(move |_theme, status| {
             let mut border_color = p.border;
@@ -56,7 +57,8 @@ where
     use iced::widget::pick_list::Status;
 
     pick_list(options, Some(selected), on_select)
-        .padding([0, 12])
+        .text_size(text_size::NORMAL)
+        .padding([3, 12])
         .style(move |_theme, status| {
             let bg = p.card_2;
             let mut border = p.border;

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -3,9 +3,13 @@ mod card;
 mod input;
 mod scrollable;
 mod sensors;
+pub mod settings_components;
 mod text;
 
-pub use button::{ButtonVisual, pill_button, pill_button_with, primary_button};
+pub use button::{
+    ButtonType, ButtonVisual, danger_button, danger_button_with, pill_button, pill_button_with,
+    primary_button,
+};
 pub use card::{card, card_with_border, fieldset, subcard};
 pub use input::{mac_input, picker, themepicker, toggler};
 pub use scrollable::scrollable;

--- a/src/ui/components/sensors.rs
+++ b/src/ui/components/sensors.rs
@@ -1,8 +1,8 @@
 use iced::widget::{checkbox, column, container, row, text};
-use iced::{Background, Border, Element, Length};
+use iced::{Alignment, Background, Border, Element, Length, Padding};
 
 use crate::app::Message;
-use crate::theme::{Palette, metric};
+use crate::theme::{Palette, metric, text_size};
 
 pub fn status_dot(p: Palette, ok: bool) -> Element<'static, Message> {
     let color = if ok { p.success } else { p.danger };
@@ -29,32 +29,13 @@ pub fn active_sensor_section(app: &crate::app::Snapdash, p: Palette) -> Element<
 
     let mut col = column![];
     for sensor in active_sensors {
-        let id = sensor.entity_id.clone();
-        let friendly_name = sensor.friendly_name.clone();
-        let id_for_msg = id.clone();
-        let row_el = row![
-            checkbox(true)
-                .label(friendly_name)
-                .on_toggle(move |_| Message::ToggleWidget(id_for_msg.clone()))
-                .text_size(14)
-                .style(move |_, _| iced::widget::checkbox::Style {
-                    background: iced::Background::Color(p.bg),
-                    text_color: Some(p.text_primary),
-                    icon_color: p.accent,
-                    border: Border {
-                        color: p.text_primary,
-                        width: 0.5,
-                        radius: 15.0.into()
-                    }
-                }),
-            text(format!(" ({})", sensor.entity_id))
-                .size(14)
-                .style(move |_: &iced::Theme| iced::widget::text::Style {
-                    color: Some(p.text_dim)
-                }),
-        ]
-        .padding(metric::PAD);
-        col = col.push(row_el);
+        col = col.push(sensor_row(
+            sensor.entity_id.as_str(),
+            sensor.friendly_name.as_str(),
+            true,
+            metric::PAD.into(),
+            p,
+        ));
     }
 
     crate::ui::components::scrollable(col.into(), p)
@@ -63,12 +44,6 @@ pub fn active_sensor_section(app: &crate::app::Snapdash, p: Palette) -> Element<
 }
 
 pub fn sensors_section(app: &crate::app::Snapdash, p: Palette) -> Element<'_, Message> {
-    // Seznam všech entit
-    // Např. jen senzory:
-    // let sensors = entities
-    //     .iter()
-    //     .filter(|e| e.entity_id.starts_with("sensor."));
-
     let query = app.entity_search_query.trim().to_lowercase();
 
     let sensors = app
@@ -79,38 +54,62 @@ pub fn sensors_section(app: &crate::app::Snapdash, p: Palette) -> Element<'_, Me
     let mut col = column![];
 
     for sensor in sensors {
-        let id = sensor.entity_id.clone();
-        let friendly = sensor.friendly_name.clone();
-        let selected = app.selected_widgets.contains(&id);
-
-        let id_for_msg = id.clone();
-
-        let row_el = row![
-            checkbox(selected)
-                .label(friendly)
-                .on_toggle(move |_| Message::ToggleWidget(id_for_msg.clone()))
-                .text_size(14)
-                .style(move |_, _| iced::widget::checkbox::Style {
-                    background: iced::Background::Color(p.bg),
-                    text_color: Some(p.text_primary),
-                    icon_color: p.accent,
-                    border: Border {
-                        color: p.text_primary,
-                        width: 0.5,
-                        radius: 15.0.into()
-                    }
-                }),
-            text(format!(" ({})", sensor.entity_id))
-                .size(14)
-                .style(move |_: &iced::Theme| iced::widget::text::Style {
-                    color: Some(p.text_dim)
-                }),
-        ]
-        .padding(8);
-        col = col.push(row_el);
+        col = col.push(sensor_row(
+            sensor.entity_id.as_str(),
+            sensor.friendly_name.as_str(),
+            app.selected_widgets.contains(&sensor.entity_id),
+            8.0.into(),
+            p,
+        ));
     }
 
     crate::ui::components::scrollable(col.into(), p)
         .height(Length::Fill)
         .into()
+}
+
+fn sensor_row<'a>(
+    entity_id: &'a str,
+    friendly_name: &'a str,
+    selected: bool,
+    padding: Padding,
+    p: Palette,
+) -> Element<'a, Message> {
+    let id_for_msg = entity_id.to_owned();
+
+    column![
+        checkbox(selected)
+            .label(friendly_name)
+            .on_toggle(move |_| Message::ToggleWidget(id_for_msg.clone()))
+            .text_size(text_size::NORMAL)
+            .style(move |_, _| iced::widget::checkbox::Style {
+                background: iced::Background::Color(p.bg),
+                text_color: Some(p.text_primary),
+                icon_color: p.accent,
+                border: Border {
+                    color: p.text_primary,
+                    width: 0.5,
+                    radius: 15.0.into()
+                }
+            }),
+        row![
+            text(format!(" ({entity_id})"))
+                .size(text_size::XSMALL)
+                .wrapping(text::Wrapping::WordOrGlyph)
+                .style(move |_: &iced::Theme| iced::widget::text::Style {
+                    color: Some(p.text_dim)
+                })
+                .align_x(Alignment::Start),
+        ]
+        .width(Length::Fill)
+        .align_y(Alignment::Start)
+        .padding(Padding {
+            top: 0.0,
+            right: 6.0,
+            bottom: 0.0,
+            left: 20.0
+        })
+    ]
+    .padding(padding)
+    .into()
 }

--- a/src/ui/components/settings_components.rs
+++ b/src/ui/components/settings_components.rs
@@ -1,0 +1,164 @@
+use crate::theme::{Palette, metric, text_size};
+use crate::ui::components;
+use crate::ui::components::button::ButtonType;
+use iced::Length;
+use iced::widget::{column, row};
+use iced::{Element, widget::text::IntoFragment};
+
+use crate::app::Message;
+
+pub fn section<'a, I>(items: I, p: Palette) -> Element<'a, Message>
+where
+    I: IntoIterator<Item = Element<'a, Message>>,
+{
+    let body = items
+        .into_iter()
+        .fold(column![].spacing(metric::GAP), |col, item| col.push(item));
+
+    components::subcard(body.into(), p)
+}
+
+pub fn page<'a, I>(title: impl IntoFragment<'a>, items: I, p: Palette) -> Element<'a, Message>
+where
+    I: IntoIterator<Item = Element<'a, Message>>,
+{
+    column![components::title(title, p), section(items, p)]
+        .spacing(metric::GAP)
+        .width(Length::Fill)
+        .into()
+}
+
+/// One row i a settings card: left side a label and optional
+/// helper text, right side carry action widget.
+fn item<'a>(
+    label: impl IntoFragment<'a>,
+    helper: Option<&'a str>,
+    action: Element<'a, Message>,
+    p: Palette,
+) -> Element<'a, Message> {
+    let mut col = column![components::body(label, p)]
+        .width(iced::Length::Fill)
+        .spacing(2);
+
+    if let Some(h) = helper {
+        col = col.push(components::helper(h, p));
+    }
+
+    row![col, action]
+        .align_y(iced::Alignment::Center)
+        .spacing(metric::GAP)
+        .into()
+}
+
+pub fn item_with_button<'a>(
+    label: impl IntoFragment<'a>,
+    helper: Option<&'a str>,
+    button_label: impl IntoFragment<'a>,
+    on_click: Option<Message>,
+    button_type: ButtonType,
+    p: Palette,
+) -> Element<'a, Message> {
+    let button = match button_type {
+        ButtonType::PILL => components::pill_button(button_label, p, on_click),
+        ButtonType::PRIMARY => components::primary_button(button_label, p, on_click),
+        ButtonType::DANGER => components::danger_button(button_label, p, on_click),
+    };
+    item(label, helper, button.into(), p)
+}
+
+pub fn item_with_toggle<'a, F>(
+    label: impl IntoFragment<'a>,
+    helper: Option<&'a str>,
+    is_checked: bool,
+    on_toggle: F,
+    p: Palette,
+) -> Element<'a, Message>
+where
+    F: Fn(bool) -> Message + 'a,
+{
+    item(
+        label,
+        helper,
+        components::toggler(is_checked, on_toggle, p).into(),
+        p,
+    )
+}
+
+pub fn item_with_picker<'a, V>(
+    label: impl IntoFragment<'a>,
+    helper: Option<&'a str>,
+    options: Vec<V>,
+    selected: V,
+    on_select: impl Fn(V) -> Message + 'a,
+    p: Palette,
+) -> Element<'a, Message>
+where
+    V: ToString + PartialEq + Clone + 'a,
+{
+    item(
+        label,
+        helper,
+        components::picker(options, selected, on_select, p).into(),
+        p,
+    )
+}
+
+pub fn item_with_status<'a>(
+    label: impl IntoFragment<'a>,
+    helper: Option<&'a str>,
+    status_text: impl IntoFragment<'a>,
+    p: Palette,
+) -> Element<'a, Message> {
+    item(label, helper, components::body(status_text, p).into(), p)
+}
+
+pub fn item_with_input<'a>(
+    label: impl IntoFragment<'a>,
+    helper: Option<&'a str>,
+    placeholder: &'a str,
+    value: &'a str,
+    on_change: impl Fn(String) -> Message + 'a,
+    on_submit: Option<Message>,
+    p: Palette,
+) -> Element<'a, Message> {
+    let mut action = components::mac_input(placeholder, value, p)
+        .on_input(on_change)
+        .size(text_size::NORMAL);
+
+    if let Some(a) = on_submit {
+        action = action.on_submit(a)
+    }
+    item(label, helper, action.into(), p)
+}
+
+pub fn item_with_icon_button<'a>(
+    label: impl IntoFragment<'a>,
+    helper: Option<&'a str>,
+    icon: crate::ui::icon::Icon,
+    on_click: Message,
+    p: Palette,
+) -> Element<'a, Message> {
+    let action: Element<'a, Message> =
+        iced::widget::mouse_area(icon.text(p).size(14).color(p.text_dim))
+            .on_press(on_click)
+            .interaction(iced::mouse::Interaction::Pointer)
+            .into();
+
+    item(label, helper, action, p)
+}
+
+/// Function will create settings item from any Element as left side
+/// and action from Element on right side.
+/// This is generic Element / Element action scope.
+/// Please use only if necessary.
+pub fn item_with_element<'a>(
+    title_element: Element<'a, Message>,
+    action_element: Element<'a, Message>,
+) -> Element<'a, Message> {
+    let col = column![title_element].width(iced::Length::Fill).spacing(2);
+
+    row![col, action_element]
+        .align_y(iced::Alignment::Center)
+        .spacing(metric::GAP)
+        .into()
+}

--- a/src/ui/components/text.rs
+++ b/src/ui/components/text.rs
@@ -3,27 +3,26 @@ use iced::widget::{column, container, text};
 use iced::{Background, Border, Element, Length};
 
 use crate::app::Message;
-use crate::theme::Palette;
+use crate::theme::{Palette, text_size};
 use crate::ui::icon::Icon;
-use crate::ui::theme::{MessageType, UiTheme};
+use crate::ui::theme::MessageType;
 
-pub fn title(label: &'static str, p: Palette) -> text::Text<'static> {
-    text(label).color(p.text_primary).size(22)
+pub fn title<'a>(label: impl IntoFragment<'a>, p: Palette) -> text::Text<'a> {
+    text(label).color(p.text_primary).size(text_size::XLARGE)
 }
 
-pub fn section(label: &'static str, p: Palette) -> text::Text<'static> {
-    text(label).color(p.text_secondary).size(16)
+pub fn section<'a>(label: impl IntoFragment<'a>, p: Palette) -> text::Text<'a> {
+    text(label).color(p.text_secondary).size(text_size::LARGE)
 }
 
-// Left here intentionaly, usage in future?
-pub fn label<S: Into<String>>(label: S, p: Palette) -> text::Text<'static> {
-    text(label.into()).color(p.text_secondary).size(14)
+pub fn label<'a>(label: impl IntoFragment<'a>, p: Palette) -> text::Text<'a> {
+    text(label).color(p.text_secondary).size(text_size::LARGE)
 }
 
-pub fn badge<'a>(label: impl Into<String>, p: Palette) -> Element<'a, Message> {
+pub fn badge<'a>(label: impl IntoFragment<'a>, p: Palette) -> Element<'a, Message> {
     container(
-        text(label.into())
-            .size(11)
+        text(label)
+            .size(text_size::NORMAL)
             .style(move |_: &iced::Theme| iced::widget::text::Style {
                 color: Some(p.accent),
             }),
@@ -42,21 +41,18 @@ pub fn badge<'a>(label: impl Into<String>, p: Palette) -> Element<'a, Message> {
 }
 
 pub fn badge_with_icon<'a>(
-    label: impl Into<String>,
+    label: impl IntoFragment<'a>,
     icon: Icon,
-    ui_theme: UiTheme,
+    p: Palette,
 ) -> Element<'a, Message> {
-    let p = ui_theme.palette;
-
-    let label_text =
-        text(label.into())
-            .size(11)
-            .style(move |_: &iced::Theme| iced::widget::text::Style {
-                color: Some(p.accent),
-            });
+    let label_text = text(label)
+        .size(text_size::NORMAL)
+        .style(move |_: &iced::Theme| iced::widget::text::Style {
+            color: Some(p.accent),
+        });
 
     let inner: Element<'a, Message> =
-        iced::widget::row![icon.text(ui_theme).color(p.accent).size(11), label_text]
+        iced::widget::row![icon.text(p).color(p.accent).size(11), label_text]
             .spacing(6)
             .align_y(iced::Alignment::Center)
             .into();
@@ -75,24 +71,24 @@ pub fn badge_with_icon<'a>(
         .into()
 }
 
-pub fn dimmed<S: Into<String>>(label: S, p: Palette) -> text::Text<'static> {
-    text(label.into()).color(p.text_dim).size(10)
-}
-
 /// Standard body text, used for setting row labels and descriptions
 /// that need to be readable at arm's length.
-pub fn body<S: Into<String>>(label: S, p: Palette) -> text::Text<'static> {
-    text(label.into()).color(p.text_body).size(13)
+pub fn body<'a>(label: impl IntoFragment<'a>, p: Palette) -> text::Text<'a> {
+    text(label).color(p.text_body).size(text_size::NORMAL)
 }
 
-pub fn helper<S: Into<String>>(label: S, p: Palette) -> text::Text<'static> {
-    text(label.into()).color(p.text_dim).size(11)
+pub fn dimmed<'a>(label: impl IntoFragment<'a>, p: Palette) -> text::Text<'a> {
+    text(label).color(p.text_dim).size(text_size::SMALL)
+}
+
+pub fn helper<'a>(label: impl IntoFragment<'a>, p: Palette) -> text::Text<'a> {
+    text(label).color(p.text_dim).size(text_size::SMALL)
 }
 
 /// Returns `column![...]` as Element<Message>
-pub fn body_with_helper<'a, S: Into<String>>(
-    label: S,
-    helper_text: S,
+pub fn body_with_helper<'a>(
+    label: impl IntoFragment<'a>,
+    helper_text: impl IntoFragment<'a>,
     p: Palette,
 ) -> Element<'a, Message> {
     column![body(label, p), helper(helper_text, p)]
@@ -114,7 +110,7 @@ pub fn message<'a>(
 
     iced::widget::container(
         iced::widget::text(content)
-            .size(12)
+            .size(text_size::SMALL)
             .style(move |_: &iced::Theme| iced::widget::text::Style { color: Some(color) }),
     )
     .padding([8, 12])

--- a/src/ui/icon.rs
+++ b/src/ui/icon.rs
@@ -6,7 +6,7 @@
 // per-OS fallback to Segoe UI Emoji on Windows (colored emoji) vs Apple
 // Symbols on macOS (thin outline) vs whatever fontconfig resolves on Linux.
 
-use crate::ui::theme::{UiTheme, icon_text};
+use crate::{theme::Palette, ui::theme::icon_text};
 
 #[derive(Copy, Clone)]
 pub enum Icon {
@@ -33,10 +33,10 @@ impl Icon {
         }
     }
 
-    pub fn text<'a>(self, ui_theme: UiTheme) -> iced::widget::Text<'a> {
+    pub fn text<'a>(self, p: Palette) -> iced::widget::Text<'a> {
         iced::widget::text(self.glyph())
             .size(Self::ICON_SIZE)
             .font(Self::ICON_FONT)
-            .style(icon_text(ui_theme, 1.0))
+            .style(icon_text(p, 1.0))
     }
 }

--- a/src/ui/release_notes.rs
+++ b/src/ui/release_notes.rs
@@ -2,13 +2,11 @@ use iced::widget::{column, container, markdown, mouse_area, row, text};
 use iced::{Alignment, Element, Length, window};
 
 use crate::app::{Message, Snapdash};
-use crate::theme::metric;
+use crate::theme::{metric, text_size};
 use crate::ui::components;
 use crate::ui::icon::Icon;
-use crate::ui::theme::UiTheme;
 
 pub fn view<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
-    let ui_theme = UiTheme::from(&snap.theme);
     let p = snap.theme.palette();
 
     let title_text = match &snap.update.latest_release {
@@ -23,9 +21,9 @@ pub fn view<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
     let title_bar: Element<Message> = row![
         mouse_area(container(title_widget).width(Length::Fill).padding([4, 0]))
             .on_press(Message::StartDrag(id)),
-        components::pill_button(
-            Icon::Close.text(ui_theme),
-            p,
+        components::pill_button_with(
+            Icon::Close.text(p),
+            components::ButtonVisual::pill(p),
             Some(Message::CloseWindow(id))
         ),
     ]
@@ -72,7 +70,7 @@ pub fn view<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
 
     let md_inner: Element<Message> = markdown::view(
         &snap.update.release_notes_items,
-        markdown::Settings::with_text_size(13, md_style),
+        markdown::Settings::with_text_size(text_size::NORMAL, md_style),
     )
     .map(Message::OpenUrl);
 

--- a/src/ui/settings/chrome.rs
+++ b/src/ui/settings/chrome.rs
@@ -7,45 +7,19 @@ use iced::widget::{container, mouse_area, row};
 use iced::{Element, Length, mouse, window};
 
 use crate::app::{Message, Snapdash};
-use crate::theme::metric;
+use crate::theme::{metric, text_size};
 use crate::ui::components;
 use crate::ui::icon::Icon;
-use crate::ui::theme::UiTheme;
 use crate::ui::update_view;
 
 pub fn title_bar<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
     let p = snap.theme.palette();
 
-    let ui_theme = UiTheme::from(&snap.theme);
-
     let update_badge: Element<Message> = if snap.update.is_available() {
-        // let inner = iced::widget::row![
-        //     Icon::Download.text(ui_theme).size(14).color(p.danger),
-        //     iced::widget::text("Update Available")
-        //         .size(12)
-        //         .style(move |_: &iced::Theme| iced::widget::text::Style {
-        //             color: Some(p.danger),
-        //         })
-        // ]
-        // .spacing(6)
-        // .align_y(iced::Alignment::Center);
-
-        // components::pill_button_with(
-        //     inner,
-        //     components::ButtonVisual::pill(p)
-        //         .bg_hovered(p.card_2)
-        //         .bg(iced::Color::TRANSPARENT)
-        //         .border(p.danger),
-        //     Some(Message::SettingsPageSelected(
-        //         crate::ui::settings::SettingsPage::Updates,
-        //     )),
-        // )
-        // .into()
-
         mouse_area(components::badge_with_icon(
             "Update Available",
             Icon::Download,
-            ui_theme,
+            p,
         ))
         .on_press(Message::OpenReleaseNotes)
         .interaction(mouse::Interaction::Pointer)
@@ -62,9 +36,9 @@ pub fn title_bar<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message>
         )
         .on_press(Message::StartDrag(id)),
         update_badge,
-        components::pill_button(
-            Icon::Close.text(ui_theme),
-            p,
+        components::pill_button_with(
+            Icon::Close.text(p).size(text_size::NORMAL),
+            components::ButtonVisual::pill(p),
             Some(Message::CloseWindow(id))
         ),
     ]
@@ -75,7 +49,6 @@ pub fn title_bar<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message>
 
 pub fn footer<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
-    let ui_theme = UiTheme::from(&snap.theme);
 
     let status: Element<Message> = if !snap.status.is_empty() {
         components::dimmed(snap.status.clone(), p).into()
@@ -87,7 +60,7 @@ pub fn footer<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let save_btn = components::primary_button("Save", p, Some(Message::SavePressed));
 
     let quit_btn = components::pill_button("Quit", p, Some(Message::QuitApp));
-    let update_icon = update_view::status_icon(snap.update.state, ui_theme, p);
+    let update_icon = update_view::status_icon(snap.update.state, p);
     let update_icon: Element<Message> = if snap.update.is_available() {
         iced::widget::mouse_area(update_icon)
             .on_press(Message::SettingsPageSelected(
@@ -118,51 +91,3 @@ pub fn footer<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     .align_y(iced::Alignment::Center)
     .into()
 }
-
-// pub fn save_row<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
-//     let p = snap.theme.palette();
-//
-//     row![
-//         components::pill_button("Save", p, Some(Message::SavePressed)),
-//         iced::widget::space().width(Length::Fill),
-//         components::pill_button("Quit App", p, Some(Message::QuitApp)),
-//     ]
-//     .spacing(metric::GAP)
-//     .align_y(iced::Alignment::Center)
-//     .into()
-// }
-//
-// pub fn status_row<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
-//     let p = snap.theme.palette();
-//     let ui_theme = UiTheme::from(&snap.theme);
-//
-//     let status: Element<Message> = if !snap.status.is_empty() {
-//         components::dimmed(snap.status.clone(), p).into()
-//     } else {
-//         components::dimmed("Status", p).into()
-//     };
-//
-//     let update_icon = update_view::status_icon(snap.update.state, ui_theme, p);
-//     let update_icon: Element<Message> = if snap.update.is_available() {
-//         mouse_area(update_icon)
-//             .on_press(Message::OpenReleaseNotes)
-//             .interaction(mouse::Interaction::Pointer)
-//             .into()
-//     } else {
-//         update_icon.into()
-//     };
-
-//     let version: Element<Message> = row![
-//         components::dimmed(format!("version: {} ", update::CURRENT_VERSION), p),
-//         update_icon
-//     ]
-//     .padding([4, 0])
-//     .into();
-//
-//     row![
-//         column![status].width(Length::Fill),
-//         column![version].align_x(iced::Alignment::End)
-//     ]
-//     .width(Length::Fill)
-//     .into()
-// }

--- a/src/ui/settings/pages/advanced.rs
+++ b/src/ui/settings/pages/advanced.rs
@@ -1,62 +1,42 @@
-use iced::widget::{column, row};
-use iced::{Element, Length};
+use iced::Element;
 
 use crate::app::{Message, Snapdash};
-use crate::theme::metric;
-use crate::ui::components;
+use crate::ui::components::ButtonType;
+use crate::ui::components::settings_components::{item_with_button, page};
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
 
-    let config_row = row![
-        column![
-            components::body("Edit config.json", p),
-            components::helper("Open the JSON config in your default editor.", p,),
-        ]
-        .width(iced::Length::Fill),
-        components::pill_button("Open", p, Some(Message::OpenConfigFile)),
-    ]
-    .align_y(iced::Alignment::Center)
-    .spacing(metric::GAP);
-
-    let log_row = row![
-        column![
-            components::body("Open log directory", p),
-            components::helper("Browse runtime logs in your file manager.", p,),
-        ]
-        .width(iced::Length::Fill),
-        components::pill_button("Open", p, Some(Message::OpenLogFile)),
-    ]
-    .align_y(iced::Alignment::Center)
-    .spacing(metric::GAP);
-
-    let reset_row = row![
-        column![
-            components::body("Reset to defaults", p),
-            components::helper(
-                "Wipes HA URL, theme and selected sensors. The HA token in the keychain is not affected.",
+    page(
+        "Advanced",
+        [
+            item_with_button(
+                "Edit config.json",
+                Some("Open the JSON config in your default editor."),
+                "Open",
+                Some(Message::OpenConfigFile),
+                ButtonType::PILL,
                 p,
             ),
-        ]
-        .width(iced::Length::Fill),
-        components::pill_button_with("Reset", components::ButtonVisual::pill(p).bg(p.danger).bg_hovered(p.danger), Some(Message::ResetConfig)),
-    ]
-    .align_y(iced::Alignment::Center)
-    .spacing(metric::GAP);
-
-    let body = column![
-        config_row,
-        iced::widget::space().height(metric::GAP),
-        log_row,
-        iced::widget::space().height(metric::GAP),
-        reset_row,
-    ]
-    .spacing(metric::GAP);
-    column![
-        components::title(snap.settings_page.label(), p),
-        components::subcard(body.into(), p)
-    ]
-    .spacing(metric::PAD)
-    .width(Length::Fill)
-    .into()
+            item_with_button(
+                "Open log directory",
+                Some("Browse runtime logs in your file manager."),
+                "Open",
+                Some(Message::OpenLogFile),
+                ButtonType::PILL,
+                p,
+            ),
+            item_with_button(
+                "Reset to defaults",
+                Some(
+                    "Wipes HA URL, theme and selected sensors. The HA token in the keychain is not affected.",
+                ),
+                "Reset",
+                Some(Message::ResetConfig),
+                ButtonType::DANGER,
+                p,
+            ),
+        ],
+        p,
+    )
 }

--- a/src/ui/settings/pages/appearance.rs
+++ b/src/ui/settings/pages/appearance.rs
@@ -1,46 +1,32 @@
-use iced::widget::{column, row};
-use iced::{Element, Length};
+use iced::Element;
 
 use crate::app::{Message, Snapdash};
-use crate::theme::metric;
-use crate::ui::components::{self, body_with_helper};
+use crate::ui::components::settings_components;
 use crate::widget_size::WidgetSize;
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
 
-    let theme_picker: Element<Message> =
-        components::themepicker(snap.theme_options.clone(), snap.theme, p).into();
-
-    let theme_row: Element<Message> = row![
-        components::body("Theme", p),
-        iced::widget::space().width(iced::Length::Fill),
-        theme_picker
-    ]
-    .align_y(iced::Alignment::Center)
-    .into();
-
-    let size_picker: Element<Message> = components::picker(
-        WidgetSize::ALL.to_vec(),
-        snap.config.widget_size,
-        Message::WidgetSizeChanged,
+    settings_components::page(
+        "Appearance",
+        [
+            settings_components::item_with_picker(
+                "Theme",
+                None,
+                snap.theme_options.clone(),
+                snap.theme,
+                Message::ThemeSelected,
+                p,
+            ),
+            settings_components::item_with_picker(
+                "Widget size",
+                Some("Affects new and currently opened widgets"),
+                WidgetSize::ALL.to_vec(),
+                snap.config.widget_size,
+                Message::WidgetSizeChanged,
+                p,
+            ),
+        ],
         p,
     )
-    .into();
-
-    let size_row: Element<Message> = row![
-        body_with_helper("Widget size", "Affects new and currently opened widgets", p),
-        iced::widget::space().width(Length::Fill),
-        size_picker
-    ]
-    .align_y(iced::Alignment::Center)
-    .spacing(metric::GAP)
-    .into();
-
-    let body: Element<Message> = column![theme_row, size_row].spacing(metric::GAP).into();
-
-    column![components::title(snap.settings_page.label(), p), body]
-        .spacing(metric::PAD)
-        .width(Length::Fill)
-        .into()
 }

--- a/src/ui/settings/pages/connection.rs
+++ b/src/ui/settings/pages/connection.rs
@@ -1,47 +1,48 @@
-use iced::widget::{column, row};
-use iced::{Element, Length};
+use iced::Element;
 
 use crate::app::{Message, Snapdash};
-use crate::theme::metric;
-use crate::ui::components;
+use crate::theme::text_size;
+use crate::ui::components::{self, settings_components};
 use crate::ui::icon::Icon;
-use crate::ui::theme::UiTheme;
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
-    let ui_theme = UiTheme::from(&snap.theme);
 
-    let url: Element<Message> = components::mac_input("Home Assistant URL", &snap.config.ha_url, p)
-        .on_input(Message::HaUrlChanged)
+    let token_item = if !snap.config.ha_token_present {
+        settings_components::item_with_input(
+            "Token",
+            Some("Enter your Home Assistant`s Long-lived token"),
+            "Long-Lived Token belong here ...",
+            &snap.ha.token_draft,
+            Message::HaTokenDraftChanged,
+            Some(Message::SavePressed),
+            p,
+        )
+    } else {
+        let title_element = components::success_message("Token is stored in the key-chain", p);
+        let action_element = components::danger_button_with(
+            Icon::Trash.text(p).size(text_size::LARGE).into(),
+            p,
+            Some(Message::HaTokenDelete),
+        )
         .into();
-
-    let placeholder = match snap.config.ha_token_present {
-        true => "Token stored in key-chain",
-        _ => "Enter your token ...",
+        settings_components::item_with_element(title_element, action_element)
     };
 
-    let token: Element<Message> = components::mac_input(placeholder, &snap.ha.token_draft, p)
-        .on_input(Message::HaTokenDraftChanged)
-        .into();
-
-    let token_delete: Element<Message> =
-        components::pill_button(Icon::Trash.text(ui_theme), p, Some(Message::HaTokenDelete)).into();
-
-    let body = components::subcard(
-        column![
-            components::section("Home Assistant", p),
-            url,
-            row![token, token_delete]
-                .spacing(metric::GAP)
-                .align_y(iced::Alignment::Center)
-        ]
-        .spacing(metric::GAP)
-        .into(),
+    settings_components::page(
+        "Connection",
+        [
+            settings_components::item_with_input(
+                "Home Assistant URL",
+                Some("Enter fully qualified URL or IP (with http or https prefix)."),
+                "Enter your Home Assistant's URL or IP address ...",
+                &snap.config.ha_url,
+                Message::HaUrlChanged,
+                Some(Message::SavePressed),
+                p,
+            ),
+            token_item,
+        ],
         p,
-    );
-
-    column![components::title(snap.settings_page.label(), p), body]
-        .width(Length::Fill)
-        .spacing(metric::GAP)
-        .into()
+    )
 }

--- a/src/ui/settings/pages/general.rs
+++ b/src/ui/settings/pages/general.rs
@@ -1,29 +1,20 @@
-use iced::widget::{column, row};
+use iced::widget::column;
 use iced::{Element, Length};
 
 use crate::app::{Message, Snapdash};
 use crate::theme::metric;
-use crate::ui::components;
+use crate::ui::components::settings_components::item_with_status;
+use crate::ui::components::{self, settings_components};
 use crate::ui::icon::Icon;
-use crate::ui::theme::UiTheme;
 use crate::update;
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
-    let ui_theme = UiTheme::from(&snap.theme);
 
     // Hero
     let hero = column![
-        iced::widget::text("Snapdash")
-            .size(28)
-            .style(move |_: &iced::Theme| iced::widget::text::Style {
-                color: Some(p.text_primary),
-            }),
-        iced::widget::text(format!("Version {}", update::CURRENT_VERSION))
-            .size(13)
-            .style(move |_: &iced::Theme| iced::widget::text::Style {
-                color: Some(p.text_secondary),
-            }),
+        components::title("Snapdash", p),
+        components::label(format!("Version {}", update::CURRENT_VERSION), p)
     ]
     .spacing(4);
 
@@ -42,35 +33,35 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
         p.text_dim
     };
 
-    let ha_row = stat_row("Home Assistant", ha_status_text, ha_color, p);
-    let sensors_row = stat_row(
-        "Selected senors",
+    let ha_row = settings_components::item_with_element(
+        components::body("Home Assistant", p).into(),
+        iced::widget::text(ha_status_text)
+            .size(13)
+            .style(move |_: &iced::Theme| iced::widget::text::Style {
+                color: Some(ha_color),
+            })
+            .into(),
+    );
+
+    let sensors_row = item_with_status(
+        "Selected sensors",
+        None,
         format!("{}", snap.selected_widgets.len()),
-        p.text_body,
         p,
     );
-    let action_config = action_link(
-        "Edit configuration",
-        "config.json",
-        Icon::Gear,
-        Message::OpenConfigFile,
-        ui_theme,
-        p,
-    );
-    let action_logs = action_link(
-        "Open log directory",
-        "Browse runtime logs",
-        Icon::Download,
-        Message::OpenLogFile,
-        ui_theme,
-        p,
-    );
+    let stats = settings_components::section([ha_row, sensors_row], p);
 
-    let stats = components::subcard(column![ha_row, sensors_row].spacing(metric::GAP).into(), p);
+    // Behavior section
+    let mut behav_items: Vec<Element<Message>> = vec![settings_components::item_with_toggle(
+        "Start at login",
+        Some("Launch Snapdash automatically when you log into your computer."),
+        snap.config.autostart,
+        Message::AutostartChanged,
+        p,
+    )];
 
-    let macos_hint: Option<Element<Message>> = if cfg!(target_os = "macos") && snap.config.autostart
-    {
-        Some(
+    if cfg!(target_os = "macos") && snap.config.autostart {
+        behav_items.push(
             components::helper(
                 "macOS may ask you to allow Snapdash in System Settings → \
                          Login Items the first time. After approval, autostart \
@@ -78,37 +69,28 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
                 p,
             )
             .into(),
-        )
-    } else {
-        None
-    };
-
-    let autostart_row: Element<Message> = row![
-        components::body_with_helper(
-            "Start at login",
-            "Launch Snapdash automatically when you log in your computer.",
-            p
-        ),
-        components::toggler(snap.config.autostart, Message::AutostartChanged, p),
-    ]
-    .align_y(iced::Alignment::Center)
-    .spacing(metric::GAP)
-    .into();
-
-    let mut behavior_inner =
-        iced::widget::column![components::section("Behavior", p), autostart_row]
-            .spacing(metric::GAP);
-
-    if let Some(hint) = macos_hint {
-        behavior_inner = behavior_inner.push(hint);
+        );
     }
 
-    let behavior = components::subcard(behavior_inner.into(), p);
+    let behav = settings_components::section(behav_items, p);
 
-    let actions = components::subcard(
-        column![action_config, action_logs]
-            .spacing(metric::GAP)
-            .into(),
+    let actions = settings_components::section(
+        [
+            settings_components::item_with_icon_button(
+                "Edit configuration",
+                Some("Open config.json in your default editor."),
+                Icon::Gear,
+                Message::OpenConfigFile,
+                p,
+            ),
+            settings_components::item_with_icon_button(
+                "Open log directory",
+                Some("Browse runtime logs in your file manager."),
+                Icon::Download,
+                Message::OpenLogFile,
+                p,
+            ),
+        ],
         p,
     );
 
@@ -117,73 +99,10 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
         hero,
         iced::widget::space().height(metric::PAD),
         stats,
-        behavior,
+        behav,
         actions,
     ]
     .spacing(metric::PAD)
     .width(Length::Fill)
-    .into()
-}
-
-fn stat_row(
-    label: &'static str,
-    value: String,
-    value_color: iced::Color,
-    p: crate::theme::Palette,
-) -> Element<'static, Message> {
-    row![
-        iced::widget::text(label)
-            .size(13)
-            .style(move |_: &iced::Theme| {
-                iced::widget::text::Style {
-                    color: Some(p.text_dim),
-                }
-            }),
-        iced::widget::space().width(Length::Fill),
-        iced::widget::text(value)
-            .size(11)
-            .style(move |_: &iced::Theme| {
-                iced::widget::text::Style {
-                    color: Some(value_color),
-                }
-            }),
-    ]
-    .align_y(iced::Alignment::Center)
-    .into()
-}
-
-fn action_link<'a>(
-    label: &'static str,
-    helper: &'static str,
-    icon: Icon,
-    msg: Message,
-    ui_theme: UiTheme,
-    p: crate::theme::Palette,
-) -> Element<'a, Message> {
-    row![
-        column![
-            iced::widget::text(label)
-                .size(13)
-                .style(move |_: &iced::Theme| {
-                    iced::widget::text::Style {
-                        color: Some(p.text_body),
-                    }
-                }),
-            iced::widget::text(helper)
-                .size(11)
-                .style(move |_: &iced::Theme| {
-                    iced::widget::text::Style {
-                        color: Some(p.text_dim),
-                    }
-                }),
-        ]
-        .spacing(2)
-        .width(Length::Fill),
-        iced::widget::mouse_area(icon.text(ui_theme).size(14).color(p.text_dim),)
-            .on_press(msg)
-            .interaction(iced::mouse::Interaction::Pointer)
-    ]
-    .align_y(iced::Alignment::Center)
-    .spacing(metric::GAP)
     .into()
 }

--- a/src/ui/settings/pages/sensors.rs
+++ b/src/ui/settings/pages/sensors.rs
@@ -32,21 +32,18 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
         p,
     );
 
-    let body: Element<'a, Message> =
-        //column![
-             row![
-                container(available_panel).width(Length::FillPortion(1)),
-                container(selected_panel).width(Length::FillPortion(1)),
-            ]
-            .spacing(metric::GAP)
-            .align_y(iced::Alignment::Start)
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .into();
-
-    //.spacing(metric::GAP)
-    //.width(Length::Fill)
-    //.height(Length::Fill)
+    let body: Element<'a, Message> = components::subcard(
+        row![
+            container(available_panel).width(Length::FillPortion(1)),
+            container(selected_panel).width(Length::FillPortion(1)),
+        ]
+        .spacing(metric::GAP)
+        .align_y(iced::Alignment::Start)
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into(),
+        p,
+    );
 
     column![components::title(snap.settings_page.label(), p), body]
         .width(Length::Fill)

--- a/src/ui/settings/pages/updates.rs
+++ b/src/ui/settings/pages/updates.rs
@@ -4,13 +4,11 @@ use iced::{Element, Length};
 use crate::app::{Message, Snapdash};
 use crate::theme::metric;
 use crate::ui::components::{self, error_message, success_message};
-use crate::ui::theme::UiTheme;
 use crate::ui::update_view;
 use crate::update::{self, InstallProgress, UpdateState};
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
-    let ui_theme = UiTheme::from(&snap.theme);
 
     let latest = match &snap.update.latest_release {
         Some(release) => release.tag_name.to_string(),
@@ -24,7 +22,7 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     };
 
     let status_row = row![
-        update_view::status_icon(snap.update.state, ui_theme, p),
+        update_view::status_icon(snap.update.state, p),
         components::label(status_text, p),
     ]
     .spacing(metric::GAP)

--- a/src/ui/settings/sidebar.rs
+++ b/src/ui/settings/sidebar.rs
@@ -3,7 +3,7 @@ use iced::widget::{Button, button, column, text};
 use iced::{Background, Border, Color, Element, Length};
 
 use crate::app::{Message, Snapdash};
-use crate::theme::{Palette, metric};
+use crate::theme::{Palette, metric, text_size};
 
 use super::SettingsPage;
 
@@ -30,7 +30,7 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
 }
 
 fn nav_item(page: SettingsPage, is_active: bool, p: Palette) -> Button<'static, Message> {
-    button(text(page.label()).size(13))
+    button(text(page.label()).size(text_size::NORMAL))
         .style(move |_theme, status| {
             let bg = if is_active {
                 p.accent_tint

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,4 +1,4 @@
-use crate::theme::ThemeKind;
+use crate::theme::{Palette, ThemeKind};
 use iced::{Color, Theme};
 
 #[derive(Clone, Copy)]
@@ -23,10 +23,9 @@ impl From<&ThemeKind> for UiTheme {
 
 /// Styl pro "ikonové" tlačítko v pravém horním rohu (gear apod.)
 pub fn icon_button<'a>(
-    ui_theme: UiTheme,
+    p: Palette,
     alpha: f32,
 ) -> impl Fn(&Theme, iced::widget::button::Status) -> iced::widget::button::Style + 'a {
-    let p = ui_theme.palette;
     move |_theme: &Theme, _status: iced::widget::button::Status| iced::widget::button::Style {
         background: None,
         border: iced::Border {
@@ -44,11 +43,7 @@ pub fn icon_button<'a>(
 }
 
 /// Styl pro text uvnitř ikonového tlačítka (pokud ho chceš zdůraznit jinak než default text)
-pub fn icon_text<'a>(
-    ui_theme: UiTheme,
-    alpha: f32,
-) -> impl Fn(&Theme) -> iced::widget::text::Style + 'a {
-    let p = ui_theme.palette;
+pub fn icon_text<'a>(p: Palette, alpha: f32) -> impl Fn(&Theme) -> iced::widget::text::Style + 'a {
     move |_theme: &Theme| iced::widget::text::Style {
         color: Some(Color {
             a: alpha,

--- a/src/ui/update_view.rs
+++ b/src/ui/update_view.rs
@@ -4,7 +4,6 @@
 
 use crate::theme::Palette;
 use crate::ui::icon::Icon;
-use crate::ui::theme::UiTheme;
 use crate::update::UpdateState;
 
 const UPDATE_ICON_SIZE: f32 = 12.0;
@@ -12,16 +11,12 @@ const UPDATE_ICON_SIZE: f32 = 12.0;
 /// Glyph + color combo for the version-status indicator shown in the
 /// settings footer. Returned as `Text` so callers can still chain
 /// `.size()`, `.color()`, etc. to override the defaults.
-pub fn status_icon<'a>(
-    state: UpdateState,
-    ui_theme: UiTheme,
-    p: Palette,
-) -> iced::widget::Text<'a> {
+pub fn status_icon<'a>(state: UpdateState, p: Palette) -> iced::widget::Text<'a> {
     let (icon, color) = match state {
         UpdateState::Unknown => (Icon::Unknown, p.text_dim),
         UpdateState::UptoDate => (Icon::Check, p.success),
         UpdateState::UpdateAvailable => (Icon::Download, p.danger),
     };
 
-    icon.text(ui_theme).size(UPDATE_ICON_SIZE).color(color)
+    icon.text(p).size(UPDATE_ICON_SIZE).color(color)
 }


### PR DESCRIPTION
- Add `theme::text_size` constants (NORMAL/SMALL/XSMALL/LARGE/XLARGE) and use them across the UI instead of bare numeric sizes.
- Switch text helpers (`title`, `section`, `label`, `body`, `helper`, `dimmed`, `badge`, `badge_with_icon`) to `IntoFragment`, drop `UiTheme` from APIs that only need a `Palette` (`Icon::text`, `icon_button`, `icon_text`, `status_icon`, `badge_with_icon`).
- Add `danger_button` / `danger_button_with` and a `ButtonType` enum; keep accent_tint on primary button hover.
- Introduce `ui::components::settings_components` with `page`, `section`, and `item_with_*` builders, and rewrite Advanced/Appearance/Connection/General pages on top of them.
- Connection page now shows a key-chain status row with a danger delete action when a token is stored.
- Factor a shared `sensor_row` in `components::sensors` and remove dead commented-out code in settings chrome and the button module.
