### PR TITLE
fix: track HA token presence from keychain

### DIFF
--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -13,7 +13,7 @@ use iced::window;
 use iced::{Element, Task};
 
 use crate::config::{Config, WidgetPosition};
-use crate::ha::token;
+use crate::ha::token::{self, TokenPresence};
 use crate::theme::ThemeKind;
 
 use super::window::{EntityWindowState, WindowKind, WindowState, find_window_id};
@@ -34,6 +34,7 @@ pub enum FocusDirection {
 #[derive(Debug)]
 pub struct Snapdash {
     pub config: Config,
+    pub token_presence: TokenPresence,
     pub theme: ThemeKind,
 
     pub ha: ha::HaState,
@@ -127,6 +128,10 @@ pub enum Message {
     RestartAfterUpdate(std::path::PathBuf),
 
     AutostartChanged(bool),
+
+    CheckHaTokenPresence,
+    HaTokenPresenceChecked(TokenPresence),
+    RetryHaTokenPresence,
 }
 
 impl Default for Snapdash {
@@ -139,6 +144,7 @@ impl Snapdash {
     pub fn new() -> Self {
         Self {
             config: Config::default(),
+            token_presence: TokenPresence::Unchecked,
             theme: ThemeKind::default(),
             ha: ha::HaState::default(),
             status: "-".into(),
@@ -314,12 +320,14 @@ impl Snapdash {
             HaEvent::Connected => {
                 self.ha.connected = true;
                 self.set_status("HA Connected", LogType::Info);
+                self.ha.auth_failed = false;
                 Task::none()
             }
             HaEvent::Disconnected(error) => {
                 self.ha.connected = false;
                 let (msg, severity) = Snapdash::ha_error_status(&error);
                 self.set_status(msg, severity);
+                self.ha.auth_failed = false;
                 Task::none()
             }
             HaEvent::InitialState(states) => {
@@ -333,7 +341,7 @@ impl Snapdash {
             HaEvent::AuthFailed(error) => {
                 self.ha.connected = false;
                 self.ha.connection = None;
-                self.config.ha_token_present = false;
+                self.ha.auth_failed = true;
 
                 let (msg, _) = Snapdash::ha_error_status(&error);
                 self.set_status(msg, LogType::Error);
@@ -469,6 +477,45 @@ impl Snapdash {
                 std::process::exit(0);
             }
 
+            Message::CheckHaTokenPresence | Message::RetryHaTokenPresence => {
+                self.token_presence = TokenPresence::Checking;
+
+                Task::perform(
+                    async {
+                        tokio::task::spawn_blocking(token::presence)
+                            .await
+                            .unwrap_or_else(|e| TokenPresence::AccessFailed(e.to_string()))
+                    },
+                    Message::HaTokenPresenceChecked,
+                )
+            }
+
+            Message::HaTokenPresenceChecked(token_status) => match token_status {
+                TokenPresence::AccessFailed(e) => {
+                    self.set_status(format!("Token auth failed: {e}"), LogType::Error);
+                    self.token_presence = TokenPresence::AccessFailed(e);
+                    Task::none()
+                }
+                TokenPresence::Missing => {
+                    self.token_presence = TokenPresence::Missing;
+                    self.config.ha_token_present = false;
+                    self.save_config()
+                }
+                TokenPresence::Present => {
+                    self.token_presence = TokenPresence::Present;
+                    self.config.ha_token_present = true;
+                    let mut tasks: Vec<Task<Message>> = vec![self.save_config()];
+
+                    if !self.config.ha_url.trim().is_empty() {
+                        let ha_connect = Task::perform(async {}, |_| Message::ConnectHa);
+                        tasks.push(ha_connect);
+                    }
+                    Task::batch(tasks)
+                }
+                TokenPresence::Checking => Task::none(),
+                TokenPresence::Unchecked => Task::none(),
+            },
+
             Message::WidgetSizeChanged(size) => {
                 self.config.widget_size = size;
 
@@ -549,32 +596,55 @@ impl Snapdash {
                 Task::none()
             }
 
-            Message::HaTokenDelete => {
-                match token::delete() {
-                    Ok(_) => {
-                        self.set_status("Token deleted from key-chain", LogType::Info);
-                        self.config.ha_token_present = false;
-                        self.ha.connection = None;
-                        self.ha.connected = false;
-                        tracing::warn!("HA disconected due to erased token.");
-                    }
-                    Err(s) => {
-                        self.set_status(s, LogType::Error);
-                    }
-                };
-                Task::none()
-            }
+            Message::HaTokenDelete => match token::delete_raw() {
+                Ok(_) => {
+                    self.config.ha_token_present = false;
+                    self.ha.connection = None;
+                    self.ha.connected = false;
+                    self.token_presence = TokenPresence::Missing;
+                    self.set_status("Token deleted from key-chain", LogType::Info);
+                    tracing::warn!("HA disconected due to erased token.");
+                    self.save_config()
+                }
+                Err(keyring::Error::NoEntry) => {
+                    self.config.ha_token_present = false;
+                    self.ha.connection = None;
+                    self.ha.connected = false;
+                    self.token_presence = TokenPresence::Missing;
+                    self.set_status("Token deleted from key-chain", LogType::Info);
+                    tracing::warn!("HA disconected due to erased token.");
+                    self.save_config()
+                }
+                Err(e) => {
+                    self.set_status(
+                        format!("Could not delete token from key-chain {e}"),
+                        LogType::Error,
+                    );
+                    self.token_presence = TokenPresence::AccessFailed(e.to_string());
+                    Task::none()
+                }
+            },
 
             Message::ConfigLoad(res) => {
                 match res {
                     Ok(cfg) => {
+                        let mut tasks: Vec<Task<Message>> = Vec::new();
+
                         self.theme = cfg.theme;
                         self.config = cfg;
                         crate::autostart::validate_state(self.config.autostart);
+
+                        tasks.push(Task::perform(
+                            async {
+                                tokio::task::spawn_blocking(token::presence)
+                                    .await
+                                    .unwrap_or_else(|e| TokenPresence::AccessFailed(e.to_string()))
+                            },
+                            Message::HaTokenPresenceChecked,
+                        ));
+
                         self.rebuild_selected_widgets();
                         self.set_status("Config loaded", LogType::Info);
-
-                        let mut tasks: Vec<Task<Message>> = Vec::new();
 
                         if !self.boot_open_done {
                             let open_task = if self.config.widgets.is_empty() {
@@ -586,9 +656,6 @@ impl Snapdash {
                             self.boot_open_done = true;
                             tasks.push(open_task);
                         }
-
-                        let connect_task = Task::perform(async {}, |_| Message::ConnectHa);
-                        tasks.push(connect_task);
 
                         return if tasks.is_empty() {
                             Task::none()
@@ -690,10 +757,12 @@ impl Snapdash {
                     match token::set(self.ha.token_draft.trim()) {
                         Ok(()) => {
                             self.config.ha_token_present = true;
+                            self.token_presence = TokenPresence::Present;
                             self.ha.token_draft.clear();
                             self.set_status("Token saved into keychain.", LogType::Info);
                         }
                         Err(e) => {
+                            self.token_presence = TokenPresence::AccessFailed(e.to_string());
                             self.set_status(format!("Keychain error: {e}"), LogType::Error);
                             return Task::none();
                         }
@@ -783,20 +852,41 @@ impl Snapdash {
             }
 
             Message::ConnectHa => {
-                if !self.config.ha_enabled() {
+                if self.config.ha_url.trim().is_empty()
+                    || matches!(self.token_presence, TokenPresence::Missing)
+                {
                     self.ha.connected = false;
                     self.ha.connection = None;
-                    self.set_status("HA not enabled (missing token/URL)", LogType::Error);
+                    if matches!(self.token_presence, TokenPresence::Missing) {
+                        self.set_status("HA not enabled - missing token", LogType::Error);
+                    } else {
+                        self.set_status("HA not enabled - URL", LogType::Error);
+                    }
                     return Task::none();
                 }
 
-                let stored_token = match token::get() {
+                let stored_token = match token::get_raw() {
                     Ok(t) => t,
                     Err(e) => {
+                        match e {
+                            keyring::Error::NoEntry => {
+                                self.set_status(
+                                    format!("Missing token in key-chain {e}"),
+                                    LogType::Error,
+                                );
+                                self.config.ha_token_present = false;
+                                self.token_presence = TokenPresence::Missing;
+                            }
+                            _ => {
+                                self.set_status(
+                                    format!("Access to key-chain was denied. {e}"),
+                                    LogType::Warn,
+                                );
+                                self.token_presence = TokenPresence::AccessFailed(e.to_string());
+                            }
+                        }
                         self.ha.connected = false;
                         self.ha.connection = None;
-                        self.set_status(format!("Missing token in keychain {e}"), LogType::Error);
-                        self.config.ha_token_present = false;
 
                         return self.save_config().chain(Task::done(Message::Noop));
                     }

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -852,19 +852,35 @@ impl Snapdash {
             }
 
             Message::ConnectHa => {
-                if self.config.ha_url.trim().is_empty()
-                    || matches!(self.token_presence, TokenPresence::Missing)
-                {
+                if self.config.ha_url.trim().is_empty() {
                     self.ha.connected = false;
                     self.ha.connection = None;
-                    if matches!(self.token_presence, TokenPresence::Missing) {
-                        self.set_status("HA not enabled - missing token", LogType::Error);
-                    } else {
-                        self.set_status("HA not enabled - URL", LogType::Error);
-                    }
+                    self.set_status("HA not enabled - URL", LogType::Error);
                     return Task::none();
                 }
 
+                match &self.token_presence {
+                    TokenPresence::Present => {}
+                    TokenPresence::Missing => {
+                        self.ha.connected = false;
+                        self.ha.connection = None;
+                        self.set_status("HA not enabled - missing token", LogType::Error);
+                        return Task::none();
+                    }
+                    TokenPresence::AccessFailed(e) => {
+                        self.ha.connected = false;
+                        self.ha.connection = None;
+                        self.set_status(format!("Keychain access needed: {e}"), LogType::Warn);
+                        return Task::none();
+                    }
+                    TokenPresence::Checking => {
+                        self.set_status("Checking token in keychain...", LogType::DoNotLog);
+                        return Task::none();
+                    }
+                    TokenPresence::Unchecked => {
+                        return Task::done(Message::CheckHaTokenPresence);
+                    }
+                }
                 let stored_token = match token::get_raw() {
                     Ok(t) => t,
                     Err(e) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,10 +56,6 @@ impl Config {
         Ok(proj.config_dir().join("config.json"))
     }
 
-    pub fn ha_enabled(&self) -> bool {
-        !self.ha_url.trim().is_empty() && self.ha_token_present
-    }
-
     pub async fn load() -> anyhow::Result<Self> {
         let path = Self::config_path()?;
         let bytes = match tokio::fs::read(&path).await {

--- a/src/ha/mod.rs
+++ b/src/ha/mod.rs
@@ -20,5 +20,7 @@ pub struct HaState {
     pub connection: Option<HaConnectionConfig>,
     /// Token entered in Settings but not yet persisted to the keychain.
     pub token_draft: String,
+    /// Sets from ws.rs if coonection is refused by HA
+    pub auth_failed: bool,
     pub entities: HashMap<String, EntityState>,
 }

--- a/src/ha/token.rs
+++ b/src/ha/token.rs
@@ -9,17 +9,32 @@ use keyring::Entry;
 const SERVICE: &str = "dev.snapdash.Snapdash";
 const USER: &str = "home-assistant-token";
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenPresence {
+    Unchecked,
+    Checking,
+    Present,
+    Missing,
+    AccessFailed(String),
+}
+
+pub fn presence() -> TokenPresence {
+    match Entry::new(SERVICE, USER).and_then(|entry| entry.get_password().map(|_| ())) {
+        Ok(()) => TokenPresence::Present,
+        Err(keyring::Error::NoEntry) => TokenPresence::Missing,
+        Err(e) => TokenPresence::AccessFailed(e.to_string()),
+    }
+}
+
 pub fn set(token: &str) -> Result<(), String> {
     let entry = Entry::new(SERVICE, USER).map_err(|e| e.to_string())?;
     entry.set_password(token).map_err(|e| e.to_string())
 }
 
-pub fn get() -> Result<String, String> {
-    let entry = Entry::new(SERVICE, USER).map_err(|e| e.to_string())?;
-    entry.get_password().map_err(|e| e.to_string())
+pub fn get_raw() -> keyring::Result<String> {
+    Entry::new(SERVICE, USER).and_then(|entry| entry.get_password())
 }
 
-pub fn delete() -> Result<(), String> {
-    let entry = Entry::new(SERVICE, USER).map_err(|e| e.to_string())?;
-    entry.delete_credential().map_err(|e| e.to_string())
+pub fn delete_raw() -> keyring::Result<()> {
+    Entry::new(SERVICE, USER).and_then(|entry| entry.delete_credential())
 }

--- a/src/ui/icon.rs
+++ b/src/ui/icon.rs
@@ -16,6 +16,7 @@ pub enum Icon {
     Trash,
     Close,
     Unknown,
+    Refresh,
 }
 
 impl Icon {
@@ -30,6 +31,7 @@ impl Icon {
             Self::Trash => '\u{e18e}',
             Self::Close => '\u{e1b2}',
             Self::Unknown => '\u{e47b}',
+            Self::Refresh => '\u{e144}',
         }
     }
 

--- a/src/ui/settings/pages/connection.rs
+++ b/src/ui/settings/pages/connection.rs
@@ -1,32 +1,66 @@
 use iced::Element;
 
 use crate::app::{Message, Snapdash};
+use crate::ha::token::TokenPresence;
 use crate::theme::text_size;
-use crate::ui::components::{self, settings_components};
+use crate::ui::components::{self, ButtonVisual, settings_components};
 use crate::ui::icon::Icon;
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
 
-    let token_item = if !snap.config.ha_token_present {
-        settings_components::item_with_input(
+    let token_item = match &snap.token_presence {
+        TokenPresence::Missing => settings_components::item_with_input(
             "Token",
             Some("Enter your Home Assistant`s Long-lived token"),
-            "Long-Lived Token belong here ...",
+            "Long-Lived Token belongs here ...",
             &snap.ha.token_draft,
             Message::HaTokenDraftChanged,
             Some(Message::SavePressed),
             p,
-        )
-    } else {
-        let title_element = components::success_message("Token is stored in the key-chain", p);
-        let action_element = components::danger_button_with(
-            Icon::Trash.text(p).size(text_size::LARGE).into(),
-            p,
-            Some(Message::HaTokenDelete),
-        )
-        .into();
-        settings_components::item_with_element(title_element, action_element)
+        ),
+        TokenPresence::Present if snap.ha.auth_failed => {
+            let title_element = components::error_message(
+                "Token possibly invalid. HA rejected authorization with AuthFailed.",
+                p,
+            );
+            let action_element = components::danger_button_with(
+                Icon::Trash.text(p).size(text_size::LARGE).into(),
+                p,
+                Some(Message::HaTokenDelete),
+            )
+            .into();
+            settings_components::item_with_element(title_element, action_element)
+        }
+        TokenPresence::Present => {
+            let title_element = components::success_message("Token is stored in the key-chain", p);
+            let action_element = components::danger_button_with(
+                Icon::Trash.text(p).size(text_size::LARGE).into(),
+                p,
+                Some(Message::HaTokenDelete),
+            )
+            .into();
+            settings_components::item_with_element(title_element, action_element)
+        }
+        TokenPresence::AccessFailed(..) => {
+            let title_element = components::error_message("Access to key-chain was denied.", p);
+            let action_element = components::pill_button_with(
+                Icon::Refresh.text(p).size(text_size::LARGE),
+                ButtonVisual::pill(p),
+                Some(Message::RetryHaTokenPresence),
+            )
+            .into();
+            settings_components::item_with_element(title_element, action_element)
+        }
+        TokenPresence::Checking | TokenPresence::Unchecked => {
+            settings_components::item_with_icon_button(
+                "Checking token",
+                Some("Trying to access your OS key-chain"),
+                Icon::Refresh,
+                Message::RetryHaTokenPresence,
+                p,
+            )
+        }
     };
 
     settings_components::page(


### PR DESCRIPTION
Add explicit runtime token presence state so the UI no longer relies on the persisted config hint as the source of truth. Gate HA connection attempts on the keychain check result, handle denied keychain access as retryable, and make token deletion idempotent when the keychain entry is already missing.

Also surface HA auth rejection in the connection UI and avoid triggering keychain reads for blank/whitespace-only URLs.
