### PR TITLE
feat: Add clear log action and settings UI

### DIFF
--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -1,4 +1,3 @@
-use crate::ha;
 use crate::ha::types::HaError;
 use crate::ha::{EntityState, HaConnectionConfig, HaEvent};
 use crate::logger::LogType;
@@ -6,6 +5,7 @@ use crate::ui::platform::window_settings;
 use crate::ui::settings::*;
 use crate::update;
 use crate::widget_size::WidgetSize;
+use crate::{ha, logger};
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
@@ -119,6 +119,7 @@ pub enum Message {
 
     OpenConfigFile,
     OpenLogFile,
+    TruncateLogFile,
     ResetConfig,
 
     WidgetSizeChanged(WidgetSize),
@@ -580,6 +581,17 @@ impl Snapdash {
                 self.set_status("Configuration rest to defaults", LogType::Info);
                 self.save_config()
             }
+
+            Message::TruncateLogFile => match logger::clear_log() {
+                Ok(_) => {
+                    self.set_status("Log has been truncated.", LogType::DoNotLog);
+                    Task::none()
+                }
+                Err(e) => {
+                    self.set_status(format!("Can not clear log. {e}"), LogType::Warn);
+                    Task::none()
+                }
+            },
 
             Message::SettingsPageSelected(page) => {
                 self.settings_page = page;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,13 @@
+//! Simple human-readable size
+pub fn humanize_bytes(n: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    match n {
+        n if n >= GB => format!("{:.1} GB", n as f64 / GB as f64),
+        n if n >= MB => format!("{:.1} MB", n as f64 / MB as f64),
+        n if n >= KB => format!("{:.1} KB", n as f64 / KB as f64),
+        n => format!("{n} B"),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod app;
 pub mod autostart;
 pub mod config;
 pub mod ha;
+pub mod helpers;
 pub mod logger;
 pub mod theme;
 pub mod ui;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -87,3 +87,42 @@ pub fn log_path() -> anyhow::Result<PathBuf> {
         .context("cannot determine app data dir")?;
     Ok(proj.data_dir().join("debug.log"))
 }
+
+/// Truncates the active log file to zero bytes. The non-blocking
+/// appender keeps writing from offset 0 afterwards, so future log
+/// lines just continue normally. A few in-flight messages from the
+/// appender's internal queue may still land at the top of the
+/// freshly-cleared file — that's a tracing-appender quirk we can't
+/// avoid without restarting the subscriber.
+pub fn clear_log() -> anyhow::Result<()> {
+    let path = log_path()?;
+
+    // I logging was disabled at startup, the file may not exists.
+    // Treat that as already cleared
+    if !path.exists() {
+        return Ok(());
+    }
+
+    std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&path)
+        .with_context(|| format!("truncate log {}", path.display()))?;
+
+    tracing::info!("log file cleared");
+    Ok(())
+}
+
+pub fn get_log_size() -> anyhow::Result<u64> {
+    let path = log_path()?;
+
+    if !path.exists() {
+        anyhow::bail!(format!("log file not found {}", path.display()))
+    };
+
+    let log_size = std::fs::metadata(&path)
+        .with_context(|| format!("error reading metadata of log file {}", path.display()))?
+        .len();
+
+    Ok(log_size)
+}

--- a/src/ui/components/settings_components.rs
+++ b/src/ui/components/settings_components.rs
@@ -28,11 +28,29 @@ where
         .into()
 }
 
+pub fn page_with_sections<'a, I>(
+    title: impl IntoFragment<'a>,
+    items: I,
+    p: Palette,
+) -> Element<'a, Message>
+where
+    I: IntoIterator<Item = Element<'a, Message>>,
+{
+    let outer = column![components::title(title, p)]
+        .spacing(metric::GAP)
+        .width(Length::Fill);
+
+    items
+        .into_iter()
+        .fold(outer, |col, item| col.push(item))
+        .into()
+}
+
 /// One row i a settings card: left side a label and optional
 /// helper text, right side carry action widget.
 fn item<'a>(
     label: impl IntoFragment<'a>,
-    helper: Option<&'a str>,
+    helper: Option<impl IntoFragment<'a>>,
     action: Element<'a, Message>,
     p: Palette,
 ) -> Element<'a, Message> {
@@ -133,7 +151,7 @@ pub fn item_with_input<'a>(
 
 pub fn item_with_icon_button<'a>(
     label: impl IntoFragment<'a>,
-    helper: Option<&'a str>,
+    helper: Option<impl IntoFragment<'a>>,
     icon: crate::ui::icon::Icon,
     on_click: Message,
     p: Palette,

--- a/src/ui/icon.rs
+++ b/src/ui/icon.rs
@@ -17,6 +17,7 @@ pub enum Icon {
     Close,
     Unknown,
     Refresh,
+    ExternalLink,
 }
 
 impl Icon {
@@ -32,6 +33,7 @@ impl Icon {
             Self::Close => '\u{e1b2}',
             Self::Unknown => '\u{e47b}',
             Self::Refresh => '\u{e144}',
+            Self::ExternalLink => '\u{e0b9}',
         }
     }
 

--- a/src/ui/settings/pages/advanced.rs
+++ b/src/ui/settings/pages/advanced.rs
@@ -2,38 +2,66 @@ use iced::Element;
 
 use crate::app::{Message, Snapdash};
 use crate::ui::components::ButtonType;
-use crate::ui::components::settings_components::{item_with_button, page};
+use crate::ui::components::settings_components::{
+    item_with_button, item_with_icon_button, page_with_sections, section,
+};
+use crate::ui::icon;
+use crate::{helpers, logger};
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
 
-    page(
+    let size = logger::get_log_size().unwrap_or(0);
+    let log_size_helper = format!(
+        "Truncate the runtime log file. Current size is {}",
+        helpers::humanize_bytes(size)
+    );
+
+    page_with_sections(
         "Advanced",
         [
-            item_with_button(
-                "Edit config.json",
-                Some("Open the JSON config in your default editor."),
-                "Open",
-                Some(Message::OpenConfigFile),
-                ButtonType::PILL,
+            // Edit section
+            section(
+                [item_with_icon_button(
+                    "Edit config.json",
+                    Some("Open the JSON config in your default editor."),
+                    icon::Icon::ExternalLink,
+                    Message::OpenConfigFile,
+                    p,
+                )],
                 p,
             ),
-            item_with_button(
-                "Open log directory",
-                Some("Browse runtime logs in your file manager."),
-                "Open",
-                Some(Message::OpenLogFile),
-                ButtonType::PILL,
+            // Log section
+            section(
+                [
+                    item_with_icon_button(
+                        "Open log directory",
+                        Some("Browse runtime logs in your file manager."),
+                        icon::Icon::ExternalLink,
+                        Message::OpenLogFile,
+                        p,
+                    ),
+                    item_with_icon_button(
+                        "Clear log file",
+                        Some(log_size_helper),
+                        icon::Icon::Refresh,
+                        Message::TruncateLogFile,
+                        p,
+                    ),
+                ],
                 p,
             ),
-            item_with_button(
-                "Reset to defaults",
-                Some(
-                    "Wipes HA URL, theme and selected sensors. The HA token in the keychain is not affected.",
-                ),
-                "Reset",
-                Some(Message::ResetConfig),
-                ButtonType::DANGER,
+            section(
+                [item_with_button(
+                    "Reset to defaults",
+                    Some(
+                        "Wipes HA URL, theme and selected sensors. The HA token in the keychain is not affected.",
+                    ),
+                    "Reset",
+                    Some(Message::ResetConfig),
+                    ButtonType::DANGER,
+                    p,
+                )],
                 p,
             ),
         ],


### PR DESCRIPTION
- Add logger::clear_log and logger::get_log_size. 
- Export helpers in lib. 
- Update settings_components to accept helper fragments and add page_with_sections helper. 
- Add ExternalLink icon and handle Message::TruncateLogFile in Snapdash
