### PR TITLE
Release version v0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4557,7 +4557,7 @@ dependencies = [
 
 [[package]]
 name = "snapdash"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "auto-launch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17918dba7ecf78b9a14507ec9f984e7977d13fad87dc86d61038980a45d128cf"
+dependencies = [
+ "dirs",
+ "os_info",
+ "smappservice-rs",
+ "thiserror 2.0.18",
+ "windows-registry",
+ "windows-result 0.4.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1013,15 @@ name = "directories"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
@@ -2717,6 +2740,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2907,7 +2942,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
 ]
 
@@ -3012,6 +3047,16 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3148,6 +3193,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-service-management"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b213642d6959cc6023ceb1217aa595eaaf09b8094ce95127c103cab611fe65e8"
+dependencies = [
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-security",
+]
+
+[[package]]
 name = "objc2-symbols"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3169,13 +3238,34 @@ dependencies = [
  "objc2-cloud-kit 0.2.2",
  "objc2-core-data 0.2.2",
  "objc2-core-image 0.2.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
  "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
- "objc2-user-notifications",
+ "objc2-user-notifications 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-location 0.3.2",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "objc2-user-notifications 0.3.2",
 ]
 
 [[package]]
@@ -3198,8 +3288,18 @@ dependencies = [
  "bitflags 2.11.1",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-core-location",
+ "objc2-core-location 0.2.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3296,6 +3396,21 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.30.1",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4357,6 +4472,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smappservice-rs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52703b97a53101cf5d4580e0737aaa634ce1fdcfc123c16b2a9658e358013488"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-service-management",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "smithay-client-toolkit"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4433,6 +4560,7 @@ name = "snapdash"
 version = "0.0.5"
 dependencies = [
  "anyhow",
+ "auto-launch",
  "chrono",
  "directories",
  "flate2",
@@ -5903,6 +6031,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6205,7 +6344,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.2.2",
  "orbclient",
  "percent-encoding",
  "pin-project",
@@ -6477,7 +6616,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
- "nix",
+ "nix 0.29.0",
  "ordered-stream",
  "rand 0.8.6",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snapdash"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 authors = ["Lukáš Svoboda <opensource@schizza.cz>"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ diagnostics = []
 
 [dependencies]
 anyhow = "1.0.102"
+auto-launch = "0.6.0"
 chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
 iced = { version = "0.14.0", features = ["wgpu", "tokio", "markdown"] }
 directories = "6.0.0"

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -67,6 +67,7 @@ pub struct Snapdash {
 pub enum Message {
     Noop,
     OpenSettings,
+    OpenSettingsTo(SettingsPage),
     OpenEntity(String),
     OpenReleaseNotes,
     OpenUrl(String),
@@ -133,6 +134,10 @@ pub enum Message {
     CheckHaTokenPresence,
     HaTokenPresenceChecked(TokenPresence),
     RetryHaTokenPresence,
+
+    AdaptiveFontChanged(bool),
+    AdaptiveValueChanged(bool),
+    ShowMeasurementInfoChanged(bool),
 }
 
 impl Default for Snapdash {
@@ -518,7 +523,7 @@ impl Snapdash {
             },
 
             Message::WidgetSizeChanged(size) => {
-                self.config.widget_size = size;
+                self.config.widget_settings.widget_size = size;
 
                 // Route the card size through the platform helper so Linux gets its
                 // SHADOW_MARGIN inflation (composited.rs:28) — same path as
@@ -787,6 +792,10 @@ impl Snapdash {
                 self.set_status("Saved", LogType::DoNotLog);
                 Task::perform(async {}, |_| Message::ConnectHa)
             }
+            Message::OpenSettingsTo(page) => {
+                self.settings_page = page;
+                self.update(Message::OpenSettings)
+            }
 
             Message::OpenSettings => {
                 // if Settings window is opened, give focus
@@ -824,8 +833,10 @@ impl Snapdash {
                         continue;
                     }
 
-                    let mut win_settings =
-                        window_settings(self.config.widget_size.window_size(), false);
+                    let mut win_settings = window_settings(
+                        self.config.widget_settings.widget_size.window_size(),
+                        false,
+                    );
                     if let Some(saved) = self.config.widget_positions.get(&widget) {
                         win_settings.position =
                             window::Position::Specific(iced::Point::new(saved.x, saved.y));
@@ -1032,6 +1043,20 @@ impl Snapdash {
                     return Task::none();
                 }
                 self.last_widget_move_at = None;
+                self.save_config()
+            }
+
+            Message::AdaptiveFontChanged(b) => {
+                self.config.widget_settings.adaptive.adaptive_font = b;
+                self.save_config()
+            }
+            Message::AdaptiveValueChanged(b) => {
+                self.config.widget_settings.adaptive.adaptive_value = b;
+                self.save_config()
+            }
+
+            Message::ShowMeasurementInfoChanged(b) => {
+                self.config.widget_settings.show_measurement_info = b;
                 self.save_config()
             }
         }

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -125,6 +125,8 @@ pub enum Message {
     InstallUpdate,
     UpdateInstelled(Result<std::path::PathBuf, String>),
     RestartAfterUpdate(std::path::PathBuf),
+
+    AutostartChanged(bool),
 }
 
 impl Default for Snapdash {
@@ -375,6 +377,27 @@ impl Snapdash {
         match message {
             Message::Noop => Task::none(),
 
+            Message::AutostartChanged(want) => {
+                let previous = self.config.autostart;
+                self.config.autostart = want;
+
+                let result = if want {
+                    crate::autostart::enable()
+                } else {
+                    crate::autostart::disable()
+                };
+
+                if let Err(e) = result {
+                    self.config.autostart = previous;
+                    tracing::error!(error = %e, want, "autostart update failed");
+                    self.set_status(format!("Autostart change failed: {e}"), LogType::Error);
+                    return Task::none();
+                }
+
+                let action = if want { "enabled" } else { "disabled" };
+                self.set_status(format!("Autostart {action}"), LogType::Info);
+                self.save_config()
+            }
             Message::InstallUpdate => {
                 // Guard
                 if !matches!(
@@ -547,6 +570,7 @@ impl Snapdash {
                     Ok(cfg) => {
                         self.theme = cfg.theme;
                         self.config = cfg;
+                        crate::autostart::validate_state(self.config.autostart);
                         self.rebuild_selected_widgets();
                         self.set_status("Config loaded", LogType::Info);
 

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -13,7 +13,7 @@ use iced::window;
 use iced::{Element, Task};
 
 use crate::config::{Config, WidgetPosition};
-use crate::ha::token;
+use crate::ha::token::{self, TokenPresence};
 use crate::theme::ThemeKind;
 
 use super::window::{EntityWindowState, WindowKind, WindowState, find_window_id};
@@ -34,6 +34,7 @@ pub enum FocusDirection {
 #[derive(Debug)]
 pub struct Snapdash {
     pub config: Config,
+    pub token_presence: TokenPresence,
     pub theme: ThemeKind,
 
     pub ha: ha::HaState,
@@ -127,6 +128,10 @@ pub enum Message {
     RestartAfterUpdate(std::path::PathBuf),
 
     AutostartChanged(bool),
+
+    CheckHaTokenPresence,
+    HaTokenPresenceChecked(TokenPresence),
+    RetryHaTokenPresence,
 }
 
 impl Default for Snapdash {
@@ -139,6 +144,7 @@ impl Snapdash {
     pub fn new() -> Self {
         Self {
             config: Config::default(),
+            token_presence: TokenPresence::Unchecked,
             theme: ThemeKind::default(),
             ha: ha::HaState::default(),
             status: "-".into(),
@@ -314,12 +320,14 @@ impl Snapdash {
             HaEvent::Connected => {
                 self.ha.connected = true;
                 self.set_status("HA Connected", LogType::Info);
+                self.ha.auth_failed = false;
                 Task::none()
             }
             HaEvent::Disconnected(error) => {
                 self.ha.connected = false;
                 let (msg, severity) = Snapdash::ha_error_status(&error);
                 self.set_status(msg, severity);
+                self.ha.auth_failed = false;
                 Task::none()
             }
             HaEvent::InitialState(states) => {
@@ -333,7 +341,7 @@ impl Snapdash {
             HaEvent::AuthFailed(error) => {
                 self.ha.connected = false;
                 self.ha.connection = None;
-                self.config.ha_token_present = false;
+                self.ha.auth_failed = true;
 
                 let (msg, _) = Snapdash::ha_error_status(&error);
                 self.set_status(msg, LogType::Error);
@@ -469,6 +477,45 @@ impl Snapdash {
                 std::process::exit(0);
             }
 
+            Message::CheckHaTokenPresence | Message::RetryHaTokenPresence => {
+                self.token_presence = TokenPresence::Checking;
+
+                Task::perform(
+                    async {
+                        tokio::task::spawn_blocking(token::presence)
+                            .await
+                            .unwrap_or_else(|e| TokenPresence::AccessFailed(e.to_string()))
+                    },
+                    Message::HaTokenPresenceChecked,
+                )
+            }
+
+            Message::HaTokenPresenceChecked(token_status) => match token_status {
+                TokenPresence::AccessFailed(e) => {
+                    self.set_status(format!("Token auth failed: {e}"), LogType::Error);
+                    self.token_presence = TokenPresence::AccessFailed(e);
+                    Task::none()
+                }
+                TokenPresence::Missing => {
+                    self.token_presence = TokenPresence::Missing;
+                    self.config.ha_token_present = false;
+                    self.save_config()
+                }
+                TokenPresence::Present => {
+                    self.token_presence = TokenPresence::Present;
+                    self.config.ha_token_present = true;
+                    let mut tasks: Vec<Task<Message>> = vec![self.save_config()];
+
+                    if !self.config.ha_url.trim().is_empty() {
+                        let ha_connect = Task::perform(async {}, |_| Message::ConnectHa);
+                        tasks.push(ha_connect);
+                    }
+                    Task::batch(tasks)
+                }
+                TokenPresence::Checking => Task::none(),
+                TokenPresence::Unchecked => Task::none(),
+            },
+
             Message::WidgetSizeChanged(size) => {
                 self.config.widget_size = size;
 
@@ -549,32 +596,55 @@ impl Snapdash {
                 Task::none()
             }
 
-            Message::HaTokenDelete => {
-                match token::delete() {
-                    Ok(_) => {
-                        self.set_status("Token deleted from key-chain", LogType::Info);
-                        self.config.ha_token_present = false;
-                        self.ha.connection = None;
-                        self.ha.connected = false;
-                        tracing::warn!("HA disconected due to erased token.");
-                    }
-                    Err(s) => {
-                        self.set_status(s, LogType::Error);
-                    }
-                };
-                Task::none()
-            }
+            Message::HaTokenDelete => match token::delete_raw() {
+                Ok(_) => {
+                    self.config.ha_token_present = false;
+                    self.ha.connection = None;
+                    self.ha.connected = false;
+                    self.token_presence = TokenPresence::Missing;
+                    self.set_status("Token deleted from key-chain", LogType::Info);
+                    tracing::warn!("HA disconected due to erased token.");
+                    self.save_config()
+                }
+                Err(keyring::Error::NoEntry) => {
+                    self.config.ha_token_present = false;
+                    self.ha.connection = None;
+                    self.ha.connected = false;
+                    self.token_presence = TokenPresence::Missing;
+                    self.set_status("Token deleted from key-chain", LogType::Info);
+                    tracing::warn!("HA disconected due to erased token.");
+                    self.save_config()
+                }
+                Err(e) => {
+                    self.set_status(
+                        format!("Could not delete token from key-chain {e}"),
+                        LogType::Error,
+                    );
+                    self.token_presence = TokenPresence::AccessFailed(e.to_string());
+                    Task::none()
+                }
+            },
 
             Message::ConfigLoad(res) => {
                 match res {
                     Ok(cfg) => {
+                        let mut tasks: Vec<Task<Message>> = Vec::new();
+
                         self.theme = cfg.theme;
                         self.config = cfg;
                         crate::autostart::validate_state(self.config.autostart);
+
+                        tasks.push(Task::perform(
+                            async {
+                                tokio::task::spawn_blocking(token::presence)
+                                    .await
+                                    .unwrap_or_else(|e| TokenPresence::AccessFailed(e.to_string()))
+                            },
+                            Message::HaTokenPresenceChecked,
+                        ));
+
                         self.rebuild_selected_widgets();
                         self.set_status("Config loaded", LogType::Info);
-
-                        let mut tasks: Vec<Task<Message>> = Vec::new();
 
                         if !self.boot_open_done {
                             let open_task = if self.config.widgets.is_empty() {
@@ -586,9 +656,6 @@ impl Snapdash {
                             self.boot_open_done = true;
                             tasks.push(open_task);
                         }
-
-                        let connect_task = Task::perform(async {}, |_| Message::ConnectHa);
-                        tasks.push(connect_task);
 
                         return if tasks.is_empty() {
                             Task::none()
@@ -690,10 +757,12 @@ impl Snapdash {
                     match token::set(self.ha.token_draft.trim()) {
                         Ok(()) => {
                             self.config.ha_token_present = true;
+                            self.token_presence = TokenPresence::Present;
                             self.ha.token_draft.clear();
                             self.set_status("Token saved into keychain.", LogType::Info);
                         }
                         Err(e) => {
+                            self.token_presence = TokenPresence::AccessFailed(e.to_string());
                             self.set_status(format!("Keychain error: {e}"), LogType::Error);
                             return Task::none();
                         }
@@ -783,20 +852,57 @@ impl Snapdash {
             }
 
             Message::ConnectHa => {
-                if !self.config.ha_enabled() {
+                if self.config.ha_url.trim().is_empty() {
                     self.ha.connected = false;
                     self.ha.connection = None;
-                    self.set_status("HA not enabled (missing token/URL)", LogType::Error);
+                    self.set_status("HA not enabled - URL", LogType::Error);
                     return Task::none();
                 }
 
-                let stored_token = match token::get() {
-                    Ok(t) => t,
-                    Err(e) => {
+                match &self.token_presence {
+                    TokenPresence::Present => {}
+                    TokenPresence::Missing => {
                         self.ha.connected = false;
                         self.ha.connection = None;
-                        self.set_status(format!("Missing token in keychain {e}"), LogType::Error);
-                        self.config.ha_token_present = false;
+                        self.set_status("HA not enabled - missing token", LogType::Error);
+                        return Task::none();
+                    }
+                    TokenPresence::AccessFailed(e) => {
+                        self.ha.connected = false;
+                        self.ha.connection = None;
+                        self.set_status(format!("Keychain access needed: {e}"), LogType::Warn);
+                        return Task::none();
+                    }
+                    TokenPresence::Checking => {
+                        self.set_status("Checking token in keychain...", LogType::DoNotLog);
+                        return Task::none();
+                    }
+                    TokenPresence::Unchecked => {
+                        return Task::done(Message::CheckHaTokenPresence);
+                    }
+                }
+                let stored_token = match token::get_raw() {
+                    Ok(t) => t,
+                    Err(e) => {
+                        match e {
+                            keyring::Error::NoEntry => {
+                                self.set_status(
+                                    format!("Missing token in key-chain {e}"),
+                                    LogType::Error,
+                                );
+                                self.config.ha_token_present = false;
+                                self.token_presence = TokenPresence::Missing;
+                            }
+                            _ => {
+                                self.set_status(
+                                    format!("Access to key-chain was denied. {e}"),
+                                    LogType::Warn,
+                                );
+                                self.token_presence = TokenPresence::AccessFailed(e.to_string());
+                            }
+                        }
+                        self.ha.connected = false;
+                        self.ha.connection = None;
 
                         return self.save_config().chain(Task::done(Message::Noop));
                     }

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -1,4 +1,3 @@
-use crate::ha;
 use crate::ha::types::HaError;
 use crate::ha::{EntityState, HaConnectionConfig, HaEvent};
 use crate::logger::LogType;
@@ -6,6 +5,7 @@ use crate::ui::platform::window_settings;
 use crate::ui::settings::*;
 use crate::update;
 use crate::widget_size::WidgetSize;
+use crate::{ha, logger};
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
@@ -119,6 +119,7 @@ pub enum Message {
 
     OpenConfigFile,
     OpenLogFile,
+    TruncateLogFile,
     ResetConfig,
 
     WidgetSizeChanged(WidgetSize),
@@ -580,6 +581,17 @@ impl Snapdash {
                 self.set_status("Configuration rest to defaults", LogType::Info);
                 self.save_config()
             }
+
+            Message::TruncateLogFile => match logger::clear_log() {
+                Ok(_) => {
+                    self.set_status("Log has been truncated.", LogType::DoNotLog);
+                    Task::none()
+                }
+                Err(e) => {
+                    self.set_status(format!("Can not clear log. {e}"), LogType::Warn);
+                    Task::none()
+                }
+            },
 
             Message::SettingsPageSelected(page) => {
                 self.settings_page = page;

--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -1,0 +1,89 @@
+//! Cross-platform autostart preference wiring. Asks the OS to launch
+//! Snapdash at user login.
+//!
+//! - macOS: writes a LaunchAgent plist under ~/Library/LaunchAgents.
+//!   First registration may surface in System Settings → Login Items
+//!   pending user approval. After that the agent persists.
+//! - Linux: drops a `.desktop` file in ~/.config/autostart per the XDG
+//!   spec. Works on GNOME, KDE Plasma, XFCE, Cinnamon. Tiling WMs
+//!   (sway, i3) need a separate xdg-autostart-launcher to honour it.
+//! - Windows: writes a string value to
+//!   HKCU\Software\Microsoft\Windows\CurrentVersion\Run.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use auto_launch::AutoLaunchBuilder;
+
+const APP_NAME: &str = "snapdash";
+
+/// Builds an AutoLaunch handle for the running binary. Resolves the
+/// path that should be registered with the OS — the .app bundle on
+/// macOS when present, otherwise the raw binary.
+fn handle() -> Result<auto_launch::AutoLaunch> {
+    let app_path = registration_path()?;
+    let path_string = app_path
+        .to_str()
+        .with_context(|| format!("non-UTF8 app path: {}", app_path.display()))?;
+
+    AutoLaunchBuilder::new()
+        .set_app_name(APP_NAME)
+        .set_app_path(path_string)
+        .set_macos_launch_mode(auto_launch::MacOSLaunchMode::LaunchAgent)
+        .build()
+        .context("build AutoLaunch handler")
+}
+
+/// Path the OS should launch.
+///
+/// On macOS, if we're running from inside a `.app` bundle, register the
+/// bundle (so OS launches `open Snapdash.app` correctly). Otherwise
+/// (dev `cargo run`, sideloaded binary) register `current_exe()`.
+fn registration_path() -> Result<PathBuf> {
+    #[cfg(target_os = "macos")]
+    if let Some(bundle) = crate::update::installer::detect_app_bundle() {
+        return Ok(bundle);
+    }
+
+    std::env::current_exe().context("resolve current_exe")
+}
+
+pub fn enable() -> Result<()> {
+    handle()?.enable().context("enable autostart")
+}
+
+pub fn disable() -> Result<()> {
+    handle()?.disable().context("disable autostart")
+}
+
+/// Whether the OS currently has a registration for our app. Best-effort:
+/// any error from the OS layer (missing config dir, malformed plist)
+/// counts as "not enabled" so callers don't panic on edge cases.
+pub fn is_enabled() -> bool {
+    handle()
+        .and_then(|h| h.is_enabled().context("query OS"))
+        .unwrap_or(false)
+}
+
+/// Reconciles the user's stored preference with the OS-level
+/// registration. Called once after config loads — if the user wants
+/// autostart but the OS has forgotten about us (manual deletion of the
+/// plist/.desktop, app moved between filesystems), re-register
+/// silently. Logs but doesn't fail boot on errors.
+pub fn validate_state(want_enabled: bool) {
+    let os_enabled = is_enabled();
+
+    if want_enabled && !os_enabled {
+        match enable() {
+            Ok(_) => tracing::info!("autostart re-registered after drift"),
+            Err(e) => tracing::warn!(error = %e, "autostart re-register failed"),
+        }
+    } else if !want_enabled && os_enabled {
+        // User stored "off" but OS still has us listed — cleanup so
+        // we don't silently autostart against the user's preference.
+        match disable() {
+            Ok(_) => tracing::info!("autostart cleared (config says off)"),
+            Err(e) => tracing::warn!(error = %e, "autostart clear failed"),
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,10 +56,6 @@ impl Config {
         Ok(proj.config_dir().join("config.json"))
     }
 
-    pub fn ha_enabled(&self) -> bool {
-        !self.ha_url.trim().is_empty() && self.ha_token_present
-    }
-
     pub async fn load() -> anyhow::Result<Self> {
         let path = Self::config_path()?;
         let bytes = match tokio::fs::read(&path).await {

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,17 +17,27 @@ pub struct Config {
     #[serde(default)]
     pub autostart: bool,
     #[serde(default)]
+    pub widget_settings: WidgetSettings,
+    #[serde(default)]
     pub widgets: Vec<String>,
     #[serde(default)]
     pub widget_positions: HashMap<String, WidgetPosition>,
-    #[serde(default)]
-    pub widget_size: crate::widget_size::WidgetSize,
 }
 
 #[derive(Clone, Debug, Copy, Serialize, Deserialize, PartialEq)]
 pub struct WidgetPosition {
     pub x: f32,
     pub y: f32,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Default)]
+pub struct WidgetSettings {
+    #[serde(default)]
+    pub widget_size: crate::widget_size::WidgetSize,
+    #[serde(default)]
+    pub adaptive: crate::widget_size::Adaptive,
+    #[serde(default)]
+    pub show_measurement_info: bool,
 }
 
 impl Default for Config {
@@ -40,7 +50,11 @@ impl Default for Config {
             debug_overlay: false,
             widgets: Vec::new(),
             widget_positions: HashMap::new(),
-            widget_size: crate::widget_size::WidgetSize::default(),
+            widget_settings: WidgetSettings {
+                widget_size: crate::widget_size::WidgetSize::default(),
+                adaptive: crate::widget_size::Adaptive::default(),
+                show_measurement_info: true,
+            },
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     #[serde(default)]
     pub debug_overlay: bool,
     #[serde(default)]
+    pub autostart: bool,
+    #[serde(default)]
     pub widgets: Vec<String>,
     #[serde(default)]
     pub widget_positions: HashMap<String, WidgetPosition>,
@@ -34,6 +36,7 @@ impl Default for Config {
             ha_url: "http://localhost:8123".into(),
             theme: ThemeKind::default(),
             ha_token_present: false,
+            autostart: false,
             debug_overlay: false,
             widgets: Vec::new(),
             widget_positions: HashMap::new(),

--- a/src/ha/mod.rs
+++ b/src/ha/mod.rs
@@ -20,5 +20,7 @@ pub struct HaState {
     pub connection: Option<HaConnectionConfig>,
     /// Token entered in Settings but not yet persisted to the keychain.
     pub token_draft: String,
+    /// Sets from ws.rs if coonection is refused by HA
+    pub auth_failed: bool,
     pub entities: HashMap<String, EntityState>,
 }

--- a/src/ha/token.rs
+++ b/src/ha/token.rs
@@ -9,17 +9,32 @@ use keyring::Entry;
 const SERVICE: &str = "dev.snapdash.Snapdash";
 const USER: &str = "home-assistant-token";
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenPresence {
+    Unchecked,
+    Checking,
+    Present,
+    Missing,
+    AccessFailed(String),
+}
+
+pub fn presence() -> TokenPresence {
+    match Entry::new(SERVICE, USER).and_then(|entry| entry.get_password().map(|_| ())) {
+        Ok(()) => TokenPresence::Present,
+        Err(keyring::Error::NoEntry) => TokenPresence::Missing,
+        Err(e) => TokenPresence::AccessFailed(e.to_string()),
+    }
+}
+
 pub fn set(token: &str) -> Result<(), String> {
     let entry = Entry::new(SERVICE, USER).map_err(|e| e.to_string())?;
     entry.set_password(token).map_err(|e| e.to_string())
 }
 
-pub fn get() -> Result<String, String> {
-    let entry = Entry::new(SERVICE, USER).map_err(|e| e.to_string())?;
-    entry.get_password().map_err(|e| e.to_string())
+pub fn get_raw() -> keyring::Result<String> {
+    Entry::new(SERVICE, USER).and_then(|entry| entry.get_password())
 }
 
-pub fn delete() -> Result<(), String> {
-    let entry = Entry::new(SERVICE, USER).map_err(|e| e.to_string())?;
-    entry.delete_credential().map_err(|e| e.to_string())
+pub fn delete_raw() -> keyring::Result<()> {
+    Entry::new(SERVICE, USER).and_then(|entry| entry.delete_credential())
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -11,3 +11,44 @@ pub fn humanize_bytes(n: u64) -> String {
         n => format!("{n} B"),
     }
 }
+
+/// Compresses "<number> <unit>" strings to SI-prefixed form when
+/// the magnitude is far from 1.0. Recognizes plain SI base units
+/// (W, Wh, V, A, Hz, B) and skips already-prefixed values
+/// ("1.5 kW") to avoid double-scaling.
+///
+/// Pass-through for non-numerical strings ("On"), unsupported units
+/// ("°C"), or values within reasonable range (1..1000).
+pub fn humanize_magnitude(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let mut parts = trimmed.splitn(2, char::is_whitespace);
+    let num_str = parts.next().unwrap_or("");
+    let unit = parts.next().unwrap_or("").trim();
+
+    let Ok(n) = num_str.parse::<f64>() else {
+        return raw.to_string();
+    };
+
+    // Only scale plain bases — skip "kW", "MWh" (already prefixed).
+    if !matches!(unit, "W" | "Wh" | "V" | "A" | "Hz" | "B" | "VA" | "VAr") {
+        return raw.to_string();
+    }
+
+    let abs = n.abs();
+    let (scaled, prefix) = if abs >= 1_000_000_000.0 {
+        (n / 1_000_000_000.0, "G")
+    } else if abs >= 1_000_000.0 {
+        (n / 1_000_000.0, "M")
+    } else if abs >= 1_000.0 {
+        (n / 1_000.0, "k")
+    } else if abs > 0.0 && abs < 0.001 {
+        (n * 1_000_000.0, "µ")
+    } else if abs > 0.0 && abs < 1.0 {
+        (n * 1_000.0, "m")
+    } else {
+        // 1..1000 range — no compression needed
+        return raw.to_string();
+    };
+
+    format!("{:.2} {}{}", scaled, prefix, unit)
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,13 @@
+//! Simple human-readable size
+pub fn humanize_bytes(n: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    match n {
+        n if n >= GB => format!("{:.1} GB", n as f64 / GB as f64),
+        n if n >= MB => format!("{:.1} MB", n as f64 / MB as f64),
+        n if n >= KB => format!("{:.1} KB", n as f64 / KB as f64),
+        n => format!("{n} B"),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod app;
 pub mod autostart;
 pub mod config;
 pub mod ha;
+pub mod helpers;
 pub mod logger;
 pub mod theme;
 pub mod ui;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod autostart;
 pub mod config;
 pub mod ha;
 pub mod logger;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -87,3 +87,42 @@ pub fn log_path() -> anyhow::Result<PathBuf> {
         .context("cannot determine app data dir")?;
     Ok(proj.data_dir().join("debug.log"))
 }
+
+/// Truncates the active log file to zero bytes. The non-blocking
+/// appender keeps writing from offset 0 afterwards, so future log
+/// lines just continue normally. A few in-flight messages from the
+/// appender's internal queue may still land at the top of the
+/// freshly-cleared file — that's a tracing-appender quirk we can't
+/// avoid without restarting the subscriber.
+pub fn clear_log() -> anyhow::Result<()> {
+    let path = log_path()?;
+
+    // I logging was disabled at startup, the file may not exists.
+    // Treat that as already cleared
+    if !path.exists() {
+        return Ok(());
+    }
+
+    std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&path)
+        .with_context(|| format!("truncate log {}", path.display()))?;
+
+    tracing::info!("log file cleared");
+    Ok(())
+}
+
+pub fn get_log_size() -> anyhow::Result<u64> {
+    let path = log_path()?;
+
+    if !path.exists() {
+        anyhow::bail!(format!("log file not found {}", path.display()))
+    };
+
+    let log_size = std::fs::metadata(&path)
+        .with_context(|| format!("error reading metadata of log file {}", path.display()))?
+        .len();
+
+    Ok(log_size)
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -113,3 +113,11 @@ pub mod metric {
     pub const PAD: f32 = 14.0;
     pub const GAP: f32 = 12.0;
 }
+
+pub mod text_size {
+    pub const NORMAL: f32 = 13.0;
+    pub const SMALL: f32 = 11.0;
+    pub const XSMALL: f32 = 10.0;
+    pub const LARGE: f32 = 15.0;
+    pub const XLARGE: f32 = 22.0;
+}

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -20,7 +20,7 @@ pub fn window_content<'a>(
             app.theme.palette(),
             app.ha.connected,
             app.update.is_available(),
-            app.config.widget_size,
+            app.config.widget_settings,
         ),
         WindowKind::ReleaseNotes => crate::ui::release_notes::view(app, id),
     }

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -5,7 +5,7 @@ use iced::{Alignment, Element, Length};
 
 use crate::app::{Message, WindowKind, WindowState};
 use crate::ui::icon::Icon;
-use crate::ui::theme::{UiTheme, icon_button};
+use crate::ui::theme::icon_button;
 
 /// Returns window content based on its kind (`Settings` / `Entity`).
 pub fn window_content<'a>(
@@ -43,12 +43,12 @@ pub fn with_gear_overlay<'a>(
         return inner;
     }
 
-    let ui_theme = UiTheme::from(&app.theme);
+    let p = app.theme.palette();
 
-    let gear_button = iced::widget::button(Icon::Gear.text(ui_theme))
+    let gear_button = iced::widget::button(Icon::Gear.text(p))
         .padding(8)
         .on_press(Message::OpenSettings)
-        .style(icon_button(ui_theme, 1.0));
+        .style(icon_button(p, 1.0));
 
     let gear_layer: Element<Message> = iced::widget::container(gear_button)
         .width(Length::Fill)

--- a/src/ui/components/button.rs
+++ b/src/ui/components/button.rs
@@ -1,6 +1,10 @@
+use iced::widget::text::IntoFragment;
 use iced::{Background, Element, Length, widget::container};
 
-use crate::{app::Message, theme::Palette};
+use crate::{
+    app::Message,
+    theme::{Palette, text_size},
+};
 
 #[derive(Clone, Copy)]
 pub struct ButtonVisual {
@@ -14,6 +18,12 @@ pub struct ButtonVisual {
     pub text: iced::Color,
     pub text_disabled: iced::Color,
     pub radius: f32,
+}
+
+pub enum ButtonType {
+    PILL,
+    PRIMARY,
+    DANGER,
 }
 
 impl ButtonVisual {
@@ -35,13 +45,37 @@ impl ButtonVisual {
     pub fn primary(p: Palette) -> Self {
         Self {
             bg: p.accent_tint,
-            bg_hovered: p.accent,
-            bg_pressed: p.accent,
+            bg_hovered: p.accent_tint,
+            bg_pressed: p.accent_tint,
             bg_disabled: p.accent_tint,
-            border: iced::Color::TRANSPARENT,
-            border_hovered: iced::Color::TRANSPARENT,
+            border: p.accent_tint,
+            border_hovered: p.accent_dim,
             border_width: 1.0,
             text: p.text_primary,
+            text_disabled: p.text_disabled,
+            radius: 999.0,
+        }
+    }
+
+    pub fn danger(p: Palette) -> Self {
+        Self {
+            bg: iced::Color {
+                a: 0.16,
+                ..p.danger
+            },
+            bg_hovered: iced::Color {
+                a: 0.24,
+                ..p.danger
+            },
+            bg_pressed: iced::Color {
+                a: 0.32,
+                ..p.danger
+            },
+            bg_disabled: p.card_2,
+            border: p.danger,
+            border_hovered: p.danger,
+            border_width: 1.0,
+            text: p.danger,
             text_disabled: p.text_disabled,
             radius: 999.0,
         }
@@ -77,6 +111,19 @@ impl ButtonVisual {
     }
 }
 
+fn button_content<'a>(content: impl Into<Element<'a, Message>>) -> Element<'a, Message> {
+    container(content)
+        .width(Length::Shrink)
+        .height(Length::Fill)
+        .center_x(Length::Shrink)
+        .center_y(Length::Fill)
+        .into()
+}
+
+fn text_content<'a>(label: impl IntoFragment<'a>) -> Element<'a, Message> {
+    iced::widget::text(label).size(text_size::NORMAL).into()
+}
+
 fn styled_button<'a>(
     content: impl Into<Element<'a, Message>>,
     visual: ButtonVisual,
@@ -108,24 +155,19 @@ fn styled_button<'a>(
                 } else {
                     visual.text
                 },
+
                 ..Default::default()
             }
         })
 }
 
 pub fn primary_button<'a>(
-    label: impl Into<Element<'a, Message>>,
+    label: impl IntoFragment<'a>,
     p: Palette,
     on_press: Option<Message>,
 ) -> iced::widget::Button<'a, Message> {
-    let content = container(label)
-        .width(Length::Shrink)
-        .height(Length::Fill)
-        .center_x(Length::Shrink)
-        .center_y(Length::Fill);
-
     let mut b = styled_button(
-        content,
+        button_content(text_content(label)),
         ButtonVisual::primary(p),
         [0, 12],
         Length::Fixed(36.0),
@@ -139,17 +181,16 @@ pub fn primary_button<'a>(
 }
 
 pub fn pill_button<'a>(
-    label: impl Into<Element<'a, Message>>,
+    label: impl IntoFragment<'a>,
     p: Palette,
     on_press: Option<Message>,
 ) -> iced::widget::Button<'a, Message> {
-    let content = container(label)
-        .width(Length::Shrink)
-        .height(Length::Fill)
-        .center_x(Length::Shrink)
-        .center_y(Length::Fill);
-
-    let mut b = styled_button(content, ButtonVisual::pill(p), [0, 12], Length::Fixed(36.0));
+    let mut b = styled_button(
+        button_content(text_content(label)),
+        ButtonVisual::pill(p),
+        [0, 12],
+        Length::Fixed(36.0),
+    );
 
     if let Some(msg) = on_press {
         b = b.on_press(msg);
@@ -162,13 +203,7 @@ pub fn pill_button_with<'a>(
     visual: ButtonVisual,
     on_press: Option<Message>,
 ) -> iced::widget::Button<'a, Message> {
-    let content = container(label)
-        .width(Length::Shrink)
-        .height(Length::Fill)
-        .center_x(Length::Shrink)
-        .center_y(Length::Fill);
-
-    let mut b = styled_button(content, visual, [0, 12], Length::Fixed(36.0));
+    let mut b = styled_button(button_content(label), visual, [0, 12], Length::Fixed(36.0));
 
     if let Some(msg) = on_press {
         b = b.on_press(msg);
@@ -176,52 +211,38 @@ pub fn pill_button_with<'a>(
     b
 }
 
-// pub fn icon(
-//     content: impl Into<Element<'static, Message>>,
-//     p: Palette,
-//     on_press: Option<Message>,
-// ) -> iced::widget::Button<'static, Message> {
-//     use iced::widget::button::Status;
+pub fn danger_button_with<'a>(
+    content: Element<'a, Message>,
+    p: Palette,
+    on_press: Option<Message>,
+) -> iced::widget::Button<'a, Message> {
+    let mut b = styled_button(
+        button_content(content),
+        ButtonVisual::danger(p),
+        [0, 12],
+        Length::Fixed(36.0),
+    );
 
-//     let mut b = button(content)
-//         .padding([0, 12])
-//         .height(36)
-//         .style(move |_theme, status| {
-//             let mut bg = p.card_2;
-//             let mut border = p.border;
+    if let Some(m) = on_press {
+        b = b.on_press(m);
+    };
+    b
+}
 
-//             match status {
-//                 Status::Hovered => {
-//                     bg = p.card;
-//                     border = p.border_hovered
-//                 }
-//                 Status::Pressed => bg = p.accent_tint,
-//                 Status::Disabled => {
-//                     bg = p.card_2;
-//                     border = p.border
-//                 }
-//                 Status::Active => {}
-//             }
+pub fn danger_button<'a>(
+    label: impl IntoFragment<'a>,
+    p: Palette,
+    on_press: Option<Message>,
+) -> iced::widget::Button<'a, Message> {
+    let mut b = styled_button(
+        button_content(text_content(label)),
+        ButtonVisual::danger(p),
+        [0, 12],
+        Length::Fixed(36.0),
+    );
 
-//             button::Style {
-//                 background: Some(Background::Color(bg)),
-//                 border: Border {
-//                     radius: 999.0.into(),
-//                     width: 1.0,
-//                     color: border,
-//                 },
-//                 text_color: if matches!(status, Status::Disabled) {
-//                     p.text_disabled
-//                 } else {
-//                     p.text_body
-//                 },
-//                 ..Default::default()
-//             }
-//         });
-
-//     if let Some(msg) = on_press {
-//         b = b.on_press(msg);
-//     }
-
-//     b
-// }
+    if let Some(msg) = on_press {
+        b = b.on_press(msg);
+    }
+    b
+}

--- a/src/ui/components/button.rs
+++ b/src/ui/components/button.rs
@@ -1,6 +1,8 @@
 use iced::widget::text::IntoFragment;
 use iced::{Background, Element, Length, widget::container};
+use iced::{Color, Padding};
 
+use crate::ui::icon::Icon;
 use crate::{
     app::Message,
     theme::{Palette, text_size},
@@ -8,6 +10,20 @@ use crate::{
 
 #[derive(Clone, Copy)]
 pub struct ButtonVisual {
+    pub bg: iced::Color,
+    pub bg_hovered: iced::Color,
+    pub bg_pressed: iced::Color,
+    pub bg_disabled: iced::Color,
+    pub border: iced::Color,
+    pub border_hovered: iced::Color,
+    pub border_width: f32,
+    pub text: iced::Color,
+    pub text_disabled: iced::Color,
+    pub radius: f32,
+}
+
+#[derive(Clone, Copy)]
+pub struct IconVisual {
     pub bg: iced::Color,
     pub bg_hovered: iced::Color,
     pub bg_pressed: iced::Color,
@@ -111,6 +127,32 @@ impl ButtonVisual {
     }
 }
 
+impl IconVisual {
+    pub fn danger(p: Palette) -> Self {
+        Self {
+            bg: iced::Color {
+                a: 0.16,
+                ..p.danger
+            },
+            bg_hovered: iced::Color {
+                a: 0.24,
+                ..p.danger
+            },
+            bg_pressed: iced::Color {
+                a: 0.32,
+                ..p.danger
+            },
+            bg_disabled: p.card_2,
+            border: p.danger,
+            border_hovered: p.danger,
+            border_width: 0.0,
+            text: p.danger,
+            text_disabled: p.text_disabled,
+            radius: 999.0,
+        }
+    }
+}
+
 fn button_content<'a>(content: impl Into<Element<'a, Message>>) -> Element<'a, Message> {
     container(content)
         .width(Length::Shrink)
@@ -127,6 +169,43 @@ fn text_content<'a>(label: impl IntoFragment<'a>) -> Element<'a, Message> {
 fn styled_button<'a>(
     content: impl Into<Element<'a, Message>>,
     visual: ButtonVisual,
+    padding: impl Into<iced::Padding>,
+    height: Length,
+) -> iced::widget::Button<'a, Message> {
+    use iced::widget::button::{Status, Style};
+
+    iced::widget::button(content)
+        .padding(padding)
+        .height(height)
+        .style(move |_theme, status| {
+            let (bg, border) = match status {
+                Status::Hovered => (visual.bg_hovered, visual.border_hovered),
+                Status::Pressed => (visual.bg_pressed, visual.border),
+                Status::Disabled => (visual.bg_disabled, visual.border),
+                Status::Active => (visual.bg, visual.border),
+            };
+
+            Style {
+                background: Some(Background::Color(bg)),
+                border: iced::Border {
+                    radius: visual.radius.into(),
+                    width: visual.border_width,
+                    color: border,
+                },
+                text_color: if matches!(status, Status::Disabled) {
+                    visual.text_disabled
+                } else {
+                    visual.text
+                },
+
+                ..Default::default()
+            }
+        })
+}
+
+fn styled_icon_button<'a>(
+    content: impl Into<Element<'a, Message>>,
+    visual: IconVisual,
     padding: impl Into<iced::Padding>,
     height: Length,
 ) -> iced::widget::Button<'a, Message> {
@@ -245,4 +324,39 @@ pub fn danger_button<'a>(
         b = b.on_press(msg);
     }
     b
+}
+
+pub fn icon_button<'a>(
+    icon: Icon,
+    hint: Element<'a, Message>,
+    color: Option<Color>,
+    text_size: Option<f32>,
+    on_click: Message,
+
+    p: Palette,
+) -> Element<'a, Message> {
+    let size = text_size.unwrap_or(crate::theme::text_size::SMALL);
+    let mut i = icon.text(p).size(size);
+    if let Some(c) = color {
+        i = i.color(c);
+    }
+
+    iced::widget::tooltip(
+        styled_icon_button(
+            i,
+            IconVisual::danger(p),
+            Padding {
+                top: 2.0,
+                bottom: 2.0,
+                left: 4.0,
+                right: 4.0,
+            },
+            Length::Shrink,
+        )
+        .on_press(on_click)
+        .width(Length::Shrink),
+        hint,
+        iced::widget::tooltip::Position::Bottom,
+    )
+    .into()
 }

--- a/src/ui/components/card.rs
+++ b/src/ui/components/card.rs
@@ -2,7 +2,7 @@ use iced::widget::{column, container, row, stack, text};
 use iced::{Background, Border, Element, Length};
 
 use crate::app::Message;
-use crate::theme::{Palette, metric};
+use crate::theme::{Palette, metric, text_size};
 
 pub fn card(content: Element<Message>, p: Palette) -> Element<Message> {
     container(content)
@@ -127,14 +127,14 @@ pub fn fieldset<'a>(
     content: Element<'a, Message>,
     p: Palette,
 ) -> Element<'a, Message> {
-    let legend_chip: Element<'a, Message> = container(text(legend).size(13).style(
+    let legend_chip: Element<'a, Message> = container(text(legend).size(text_size::SMALL).style(
         move |_: &iced::Theme| iced::widget::text::Style {
             color: Some(p.text_dim),
         },
     ))
     .padding([0, 8])
     .style(move |_: &iced::Theme| iced::widget::container::Style {
-        background: Some(Background::Color(p.card_2)),
+        background: Some(p.card_2.into()),
         ..Default::default()
     })
     .into();

--- a/src/ui/components/input.rs
+++ b/src/ui/components/input.rs
@@ -106,3 +106,35 @@ pub fn themepicker(
 ) -> pick_list::PickList<'static, ThemeKind, Vec<ThemeKind>, ThemeKind, Message> {
     picker(options, selected, Message::ThemeSelected, p)
 }
+
+pub fn toggler<'a, F, M>(is_checked: bool, on_toggle: F, p: Palette) -> iced::widget::Toggler<'a, M>
+where
+    F: Fn(bool) -> M + 'a,
+    M: Clone + 'a,
+{
+    iced::widget::toggler(is_checked)
+        .on_toggle(on_toggle)
+        .size(20)
+        .style(move |_theme, status| {
+            use iced::widget::toggler::{Status, Style};
+
+            let active = matches!(status, Status::Active { is_toggled: true })
+                || matches!(status, Status::Hovered { is_toggled: true });
+
+            Style {
+                background: if active {
+                    p.accent_tint.into()
+                } else {
+                    p.card_2.into()
+                },
+                background_border_width: 1.0,
+                background_border_color: if active { p.accent } else { p.border },
+                foreground: p.accent.into(),
+                foreground_border_width: 0.0,
+                foreground_border_color: iced::Color::TRANSPARENT,
+                text_color: p.text_body.into(),
+                border_radius: Some(999.0.into()),
+                padding_ratio: 0.15,
+            }
+        })
+}

--- a/src/ui/components/input.rs
+++ b/src/ui/components/input.rs
@@ -3,7 +3,7 @@ use iced::widget::{pick_list, text_input};
 use iced::{Background, Border};
 
 use crate::app::Message;
-use crate::theme::{Palette, ThemeKind, metric};
+use crate::theme::{Palette, ThemeKind, metric, text_size};
 
 /// text_input wrapper to sytle as mac input
 pub fn mac_input<'a>(
@@ -14,6 +14,7 @@ pub fn mac_input<'a>(
     use iced::widget::text_input::Status;
 
     text_input(placeholder, value)
+        .size(text_size::NORMAL)
         .padding(10)
         .style(move |_theme, status| {
             let mut border_color = p.border;
@@ -56,7 +57,8 @@ where
     use iced::widget::pick_list::Status;
 
     pick_list(options, Some(selected), on_select)
-        .padding([0, 12])
+        .text_size(text_size::NORMAL)
+        .padding([3, 12])
         .style(move |_theme, status| {
             let bg = p.card_2;
             let mut border = p.border;

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -7,7 +7,7 @@ mod text;
 
 pub use button::{ButtonVisual, pill_button, pill_button_with, primary_button};
 pub use card::{card, card_with_border, fieldset, subcard};
-pub use input::{mac_input, picker, themepicker};
+pub use input::{mac_input, picker, themepicker, toggler};
 pub use scrollable::scrollable;
 pub use sensors::{active_sensor_section, sensors_section, status_dot};
 pub use text::{

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -3,9 +3,13 @@ mod card;
 mod input;
 mod scrollable;
 mod sensors;
+pub mod settings_components;
 mod text;
 
-pub use button::{ButtonVisual, pill_button, pill_button_with, primary_button};
+pub use button::{
+    ButtonType, ButtonVisual, danger_button, danger_button_with, pill_button, pill_button_with,
+    primary_button,
+};
 pub use card::{card, card_with_border, fieldset, subcard};
 pub use input::{mac_input, picker, themepicker, toggler};
 pub use scrollable::scrollable;

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -7,8 +7,8 @@ pub mod settings_components;
 mod text;
 
 pub use button::{
-    ButtonType, ButtonVisual, danger_button, danger_button_with, pill_button, pill_button_with,
-    primary_button,
+    ButtonType, ButtonVisual, danger_button, danger_button_with, icon_button, pill_button,
+    pill_button_with, primary_button,
 };
 pub use card::{card, card_with_border, fieldset, subcard};
 pub use input::{mac_input, picker, themepicker, toggler};
@@ -16,5 +16,5 @@ pub use scrollable::scrollable;
 pub use sensors::{active_sensor_section, sensors_section, status_dot};
 pub use text::{
     badge, badge_with_icon, body, body_with_helper, dimmed, error_message, helper, label, section,
-    success_message, title,
+    success_message, title, tooltip_message,
 };

--- a/src/ui/components/sensors.rs
+++ b/src/ui/components/sensors.rs
@@ -1,8 +1,8 @@
 use iced::widget::{checkbox, column, container, row, text};
-use iced::{Background, Border, Element, Length};
+use iced::{Alignment, Background, Border, Element, Length, Padding};
 
 use crate::app::Message;
-use crate::theme::{Palette, metric};
+use crate::theme::{Palette, metric, text_size};
 
 pub fn status_dot(p: Palette, ok: bool) -> Element<'static, Message> {
     let color = if ok { p.success } else { p.danger };
@@ -29,32 +29,13 @@ pub fn active_sensor_section(app: &crate::app::Snapdash, p: Palette) -> Element<
 
     let mut col = column![];
     for sensor in active_sensors {
-        let id = sensor.entity_id.clone();
-        let friendly_name = sensor.friendly_name.clone();
-        let id_for_msg = id.clone();
-        let row_el = row![
-            checkbox(true)
-                .label(friendly_name)
-                .on_toggle(move |_| Message::ToggleWidget(id_for_msg.clone()))
-                .text_size(14)
-                .style(move |_, _| iced::widget::checkbox::Style {
-                    background: iced::Background::Color(p.bg),
-                    text_color: Some(p.text_primary),
-                    icon_color: p.accent,
-                    border: Border {
-                        color: p.text_primary,
-                        width: 0.5,
-                        radius: 15.0.into()
-                    }
-                }),
-            text(format!(" ({})", sensor.entity_id))
-                .size(14)
-                .style(move |_: &iced::Theme| iced::widget::text::Style {
-                    color: Some(p.text_dim)
-                }),
-        ]
-        .padding(metric::PAD);
-        col = col.push(row_el);
+        col = col.push(sensor_row(
+            sensor.entity_id.as_str(),
+            sensor.friendly_name.as_str(),
+            true,
+            metric::PAD.into(),
+            p,
+        ));
     }
 
     crate::ui::components::scrollable(col.into(), p)
@@ -63,12 +44,6 @@ pub fn active_sensor_section(app: &crate::app::Snapdash, p: Palette) -> Element<
 }
 
 pub fn sensors_section(app: &crate::app::Snapdash, p: Palette) -> Element<'_, Message> {
-    // Seznam všech entit
-    // Např. jen senzory:
-    // let sensors = entities
-    //     .iter()
-    //     .filter(|e| e.entity_id.starts_with("sensor."));
-
     let query = app.entity_search_query.trim().to_lowercase();
 
     let sensors = app
@@ -79,38 +54,62 @@ pub fn sensors_section(app: &crate::app::Snapdash, p: Palette) -> Element<'_, Me
     let mut col = column![];
 
     for sensor in sensors {
-        let id = sensor.entity_id.clone();
-        let friendly = sensor.friendly_name.clone();
-        let selected = app.selected_widgets.contains(&id);
-
-        let id_for_msg = id.clone();
-
-        let row_el = row![
-            checkbox(selected)
-                .label(friendly)
-                .on_toggle(move |_| Message::ToggleWidget(id_for_msg.clone()))
-                .text_size(14)
-                .style(move |_, _| iced::widget::checkbox::Style {
-                    background: iced::Background::Color(p.bg),
-                    text_color: Some(p.text_primary),
-                    icon_color: p.accent,
-                    border: Border {
-                        color: p.text_primary,
-                        width: 0.5,
-                        radius: 15.0.into()
-                    }
-                }),
-            text(format!(" ({})", sensor.entity_id))
-                .size(14)
-                .style(move |_: &iced::Theme| iced::widget::text::Style {
-                    color: Some(p.text_dim)
-                }),
-        ]
-        .padding(8);
-        col = col.push(row_el);
+        col = col.push(sensor_row(
+            sensor.entity_id.as_str(),
+            sensor.friendly_name.as_str(),
+            app.selected_widgets.contains(&sensor.entity_id),
+            8.0.into(),
+            p,
+        ));
     }
 
     crate::ui::components::scrollable(col.into(), p)
         .height(Length::Fill)
         .into()
+}
+
+fn sensor_row<'a>(
+    entity_id: &'a str,
+    friendly_name: &'a str,
+    selected: bool,
+    padding: Padding,
+    p: Palette,
+) -> Element<'a, Message> {
+    let id_for_msg = entity_id.to_owned();
+
+    column![
+        checkbox(selected)
+            .label(friendly_name)
+            .on_toggle(move |_| Message::ToggleWidget(id_for_msg.clone()))
+            .text_size(text_size::NORMAL)
+            .style(move |_, _| iced::widget::checkbox::Style {
+                background: iced::Background::Color(p.bg),
+                text_color: Some(p.text_primary),
+                icon_color: p.accent,
+                border: Border {
+                    color: p.text_primary,
+                    width: 0.5,
+                    radius: 15.0.into()
+                }
+            }),
+        row![
+            text(format!(" ({entity_id})"))
+                .size(text_size::XSMALL)
+                .wrapping(text::Wrapping::WordOrGlyph)
+                .style(move |_: &iced::Theme| iced::widget::text::Style {
+                    color: Some(p.text_dim)
+                })
+                .align_x(Alignment::Start),
+        ]
+        .width(Length::Fill)
+        .align_y(Alignment::Start)
+        .padding(Padding {
+            top: 0.0,
+            right: 6.0,
+            bottom: 0.0,
+            left: 20.0
+        })
+    ]
+    .padding(padding)
+    .into()
 }

--- a/src/ui/components/settings_components.rs
+++ b/src/ui/components/settings_components.rs
@@ -1,0 +1,164 @@
+use crate::theme::{Palette, metric, text_size};
+use crate::ui::components;
+use crate::ui::components::button::ButtonType;
+use iced::Length;
+use iced::widget::{column, row};
+use iced::{Element, widget::text::IntoFragment};
+
+use crate::app::Message;
+
+pub fn section<'a, I>(items: I, p: Palette) -> Element<'a, Message>
+where
+    I: IntoIterator<Item = Element<'a, Message>>,
+{
+    let body = items
+        .into_iter()
+        .fold(column![].spacing(metric::GAP), |col, item| col.push(item));
+
+    components::subcard(body.into(), p)
+}
+
+pub fn page<'a, I>(title: impl IntoFragment<'a>, items: I, p: Palette) -> Element<'a, Message>
+where
+    I: IntoIterator<Item = Element<'a, Message>>,
+{
+    column![components::title(title, p), section(items, p)]
+        .spacing(metric::GAP)
+        .width(Length::Fill)
+        .into()
+}
+
+/// One row i a settings card: left side a label and optional
+/// helper text, right side carry action widget.
+fn item<'a>(
+    label: impl IntoFragment<'a>,
+    helper: Option<&'a str>,
+    action: Element<'a, Message>,
+    p: Palette,
+) -> Element<'a, Message> {
+    let mut col = column![components::body(label, p)]
+        .width(iced::Length::Fill)
+        .spacing(2);
+
+    if let Some(h) = helper {
+        col = col.push(components::helper(h, p));
+    }
+
+    row![col, action]
+        .align_y(iced::Alignment::Center)
+        .spacing(metric::GAP)
+        .into()
+}
+
+pub fn item_with_button<'a>(
+    label: impl IntoFragment<'a>,
+    helper: Option<&'a str>,
+    button_label: impl IntoFragment<'a>,
+    on_click: Option<Message>,
+    button_type: ButtonType,
+    p: Palette,
+) -> Element<'a, Message> {
+    let button = match button_type {
+        ButtonType::PILL => components::pill_button(button_label, p, on_click),
+        ButtonType::PRIMARY => components::primary_button(button_label, p, on_click),
+        ButtonType::DANGER => components::danger_button(button_label, p, on_click),
+    };
+    item(label, helper, button.into(), p)
+}
+
+pub fn item_with_toggle<'a, F>(
+    label: impl IntoFragment<'a>,
+    helper: Option<&'a str>,
+    is_checked: bool,
+    on_toggle: F,
+    p: Palette,
+) -> Element<'a, Message>
+where
+    F: Fn(bool) -> Message + 'a,
+{
+    item(
+        label,
+        helper,
+        components::toggler(is_checked, on_toggle, p).into(),
+        p,
+    )
+}
+
+pub fn item_with_picker<'a, V>(
+    label: impl IntoFragment<'a>,
+    helper: Option<&'a str>,
+    options: Vec<V>,
+    selected: V,
+    on_select: impl Fn(V) -> Message + 'a,
+    p: Palette,
+) -> Element<'a, Message>
+where
+    V: ToString + PartialEq + Clone + 'a,
+{
+    item(
+        label,
+        helper,
+        components::picker(options, selected, on_select, p).into(),
+        p,
+    )
+}
+
+pub fn item_with_status<'a>(
+    label: impl IntoFragment<'a>,
+    helper: Option<&'a str>,
+    status_text: impl IntoFragment<'a>,
+    p: Palette,
+) -> Element<'a, Message> {
+    item(label, helper, components::body(status_text, p).into(), p)
+}
+
+pub fn item_with_input<'a>(
+    label: impl IntoFragment<'a>,
+    helper: Option<&'a str>,
+    placeholder: &'a str,
+    value: &'a str,
+    on_change: impl Fn(String) -> Message + 'a,
+    on_submit: Option<Message>,
+    p: Palette,
+) -> Element<'a, Message> {
+    let mut action = components::mac_input(placeholder, value, p)
+        .on_input(on_change)
+        .size(text_size::NORMAL);
+
+    if let Some(a) = on_submit {
+        action = action.on_submit(a)
+    }
+    item(label, helper, action.into(), p)
+}
+
+pub fn item_with_icon_button<'a>(
+    label: impl IntoFragment<'a>,
+    helper: Option<&'a str>,
+    icon: crate::ui::icon::Icon,
+    on_click: Message,
+    p: Palette,
+) -> Element<'a, Message> {
+    let action: Element<'a, Message> =
+        iced::widget::mouse_area(icon.text(p).size(14).color(p.text_dim))
+            .on_press(on_click)
+            .interaction(iced::mouse::Interaction::Pointer)
+            .into();
+
+    item(label, helper, action, p)
+}
+
+/// Function will create settings item from any Element as left side
+/// and action from Element on right side.
+/// This is generic Element / Element action scope.
+/// Please use only if necessary.
+pub fn item_with_element<'a>(
+    title_element: Element<'a, Message>,
+    action_element: Element<'a, Message>,
+) -> Element<'a, Message> {
+    let col = column![title_element].width(iced::Length::Fill).spacing(2);
+
+    row![col, action_element]
+        .align_y(iced::Alignment::Center)
+        .spacing(metric::GAP)
+        .into()
+}

--- a/src/ui/components/settings_components.rs
+++ b/src/ui/components/settings_components.rs
@@ -28,11 +28,29 @@ where
         .into()
 }
 
+pub fn page_with_sections<'a, I>(
+    title: impl IntoFragment<'a>,
+    items: I,
+    p: Palette,
+) -> Element<'a, Message>
+where
+    I: IntoIterator<Item = Element<'a, Message>>,
+{
+    let outer = column![components::title(title, p)]
+        .spacing(metric::GAP)
+        .width(Length::Fill);
+
+    items
+        .into_iter()
+        .fold(outer, |col, item| col.push(item))
+        .into()
+}
+
 /// One row i a settings card: left side a label and optional
 /// helper text, right side carry action widget.
 fn item<'a>(
     label: impl IntoFragment<'a>,
-    helper: Option<&'a str>,
+    helper: Option<impl IntoFragment<'a>>,
     action: Element<'a, Message>,
     p: Palette,
 ) -> Element<'a, Message> {
@@ -133,7 +151,7 @@ pub fn item_with_input<'a>(
 
 pub fn item_with_icon_button<'a>(
     label: impl IntoFragment<'a>,
-    helper: Option<&'a str>,
+    helper: Option<impl IntoFragment<'a>>,
     icon: crate::ui::icon::Icon,
     on_click: Message,
     p: Palette,

--- a/src/ui/components/text.rs
+++ b/src/ui/components/text.rs
@@ -96,8 +96,41 @@ pub fn body_with_helper<'a>(
         .spacing(2)
         .into()
 }
-
+/// alpha is tuple: backgroud alpha, border alpha
 pub fn message<'a>(
+    content: impl IntoFragment<'a>,
+    msg_type: MessageType,
+    alpha: (f32, f32),
+    p: Palette,
+) -> Element<'a, Message> {
+    let color = match msg_type {
+        MessageType::Error => p.danger,
+        MessageType::Warning => p.accent,
+        MessageType::Success => p.success,
+    };
+
+    let (bg_a, b_a) = alpha;
+
+    iced::widget::container(
+        iced::widget::text(content)
+            .size(text_size::SMALL)
+            .style(move |_: &iced::Theme| iced::widget::text::Style { color: Some(color) }),
+    )
+    .padding([8, 12])
+    .style(move |_| iced::widget::container::Style {
+        background: Some(iced::Background::Color(iced::Color { a: bg_a, ..color })),
+        border: iced::Border {
+            radius: 6.0.into(),
+            width: 1.0,
+            color: iced::Color { a: b_a, ..color },
+        },
+        ..Default::default()
+    })
+    .width(iced::Length::Fill)
+    .into()
+}
+
+pub fn tooltip_message<'a>(
     content: impl IntoFragment<'a>,
     msg_type: MessageType,
     p: Palette,
@@ -115,7 +148,7 @@ pub fn message<'a>(
     )
     .padding([8, 12])
     .style(move |_| iced::widget::container::Style {
-        background: Some(iced::Background::Color(iced::Color { a: 0.12, ..color })),
+        background: Some(iced::Background::Color(p.card_2)),
         border: iced::Border {
             radius: 6.0.into(),
             width: 1.0,
@@ -128,9 +161,9 @@ pub fn message<'a>(
 }
 
 pub fn error_message<'a>(content: impl IntoFragment<'a>, p: Palette) -> Element<'a, Message> {
-    message(content, MessageType::Error, p)
+    message(content, MessageType::Error, (0.12, 0.4), p)
 }
 
 pub fn success_message<'a>(content: impl IntoFragment<'a>, p: Palette) -> Element<'a, Message> {
-    message(content, MessageType::Success, p)
+    message(content, MessageType::Success, (0.12, 0.4), p)
 }

--- a/src/ui/components/text.rs
+++ b/src/ui/components/text.rs
@@ -89,6 +89,7 @@ pub fn helper<S: Into<String>>(label: S, p: Palette) -> text::Text<'static> {
     text(label.into()).color(p.text_dim).size(11)
 }
 
+/// Returns `column![...]` as Element<Message>
 pub fn body_with_helper<'a, S: Into<String>>(
     label: S,
     helper_text: S,
@@ -96,6 +97,7 @@ pub fn body_with_helper<'a, S: Into<String>>(
 ) -> Element<'a, Message> {
     column![body(label, p), helper(helper_text, p)]
         .width(Length::Fill)
+        .spacing(2)
         .into()
 }
 

--- a/src/ui/components/text.rs
+++ b/src/ui/components/text.rs
@@ -3,27 +3,26 @@ use iced::widget::{column, container, text};
 use iced::{Background, Border, Element, Length};
 
 use crate::app::Message;
-use crate::theme::Palette;
+use crate::theme::{Palette, text_size};
 use crate::ui::icon::Icon;
-use crate::ui::theme::{MessageType, UiTheme};
+use crate::ui::theme::MessageType;
 
-pub fn title(label: &'static str, p: Palette) -> text::Text<'static> {
-    text(label).color(p.text_primary).size(22)
+pub fn title<'a>(label: impl IntoFragment<'a>, p: Palette) -> text::Text<'a> {
+    text(label).color(p.text_primary).size(text_size::XLARGE)
 }
 
-pub fn section(label: &'static str, p: Palette) -> text::Text<'static> {
-    text(label).color(p.text_secondary).size(16)
+pub fn section<'a>(label: impl IntoFragment<'a>, p: Palette) -> text::Text<'a> {
+    text(label).color(p.text_secondary).size(text_size::LARGE)
 }
 
-// Left here intentionaly, usage in future?
-pub fn label<S: Into<String>>(label: S, p: Palette) -> text::Text<'static> {
-    text(label.into()).color(p.text_secondary).size(14)
+pub fn label<'a>(label: impl IntoFragment<'a>, p: Palette) -> text::Text<'a> {
+    text(label).color(p.text_secondary).size(text_size::LARGE)
 }
 
-pub fn badge<'a>(label: impl Into<String>, p: Palette) -> Element<'a, Message> {
+pub fn badge<'a>(label: impl IntoFragment<'a>, p: Palette) -> Element<'a, Message> {
     container(
-        text(label.into())
-            .size(11)
+        text(label)
+            .size(text_size::NORMAL)
             .style(move |_: &iced::Theme| iced::widget::text::Style {
                 color: Some(p.accent),
             }),
@@ -42,21 +41,18 @@ pub fn badge<'a>(label: impl Into<String>, p: Palette) -> Element<'a, Message> {
 }
 
 pub fn badge_with_icon<'a>(
-    label: impl Into<String>,
+    label: impl IntoFragment<'a>,
     icon: Icon,
-    ui_theme: UiTheme,
+    p: Palette,
 ) -> Element<'a, Message> {
-    let p = ui_theme.palette;
-
-    let label_text =
-        text(label.into())
-            .size(11)
-            .style(move |_: &iced::Theme| iced::widget::text::Style {
-                color: Some(p.accent),
-            });
+    let label_text = text(label)
+        .size(text_size::NORMAL)
+        .style(move |_: &iced::Theme| iced::widget::text::Style {
+            color: Some(p.accent),
+        });
 
     let inner: Element<'a, Message> =
-        iced::widget::row![icon.text(ui_theme).color(p.accent).size(11), label_text]
+        iced::widget::row![icon.text(p).color(p.accent).size(11), label_text]
             .spacing(6)
             .align_y(iced::Alignment::Center)
             .into();
@@ -75,24 +71,24 @@ pub fn badge_with_icon<'a>(
         .into()
 }
 
-pub fn dimmed<S: Into<String>>(label: S, p: Palette) -> text::Text<'static> {
-    text(label.into()).color(p.text_dim).size(10)
-}
-
 /// Standard body text, used for setting row labels and descriptions
 /// that need to be readable at arm's length.
-pub fn body<S: Into<String>>(label: S, p: Palette) -> text::Text<'static> {
-    text(label.into()).color(p.text_body).size(13)
+pub fn body<'a>(label: impl IntoFragment<'a>, p: Palette) -> text::Text<'a> {
+    text(label).color(p.text_body).size(text_size::NORMAL)
 }
 
-pub fn helper<S: Into<String>>(label: S, p: Palette) -> text::Text<'static> {
-    text(label.into()).color(p.text_dim).size(11)
+pub fn dimmed<'a>(label: impl IntoFragment<'a>, p: Palette) -> text::Text<'a> {
+    text(label).color(p.text_dim).size(text_size::SMALL)
+}
+
+pub fn helper<'a>(label: impl IntoFragment<'a>, p: Palette) -> text::Text<'a> {
+    text(label).color(p.text_dim).size(text_size::SMALL)
 }
 
 /// Returns `column![...]` as Element<Message>
-pub fn body_with_helper<'a, S: Into<String>>(
-    label: S,
-    helper_text: S,
+pub fn body_with_helper<'a>(
+    label: impl IntoFragment<'a>,
+    helper_text: impl IntoFragment<'a>,
     p: Palette,
 ) -> Element<'a, Message> {
     column![body(label, p), helper(helper_text, p)]
@@ -114,7 +110,7 @@ pub fn message<'a>(
 
     iced::widget::container(
         iced::widget::text(content)
-            .size(12)
+            .size(text_size::SMALL)
             .style(move |_: &iced::Theme| iced::widget::text::Style { color: Some(color) }),
     )
     .padding([8, 12])

--- a/src/ui/entity_window.rs
+++ b/src/ui/entity_window.rs
@@ -23,30 +23,10 @@ fn format_main_value(
     }
 }
 
-fn status_line(p: Palette, connected: bool, size: WidgetSize) -> Element<'static, Message> {
+fn status_line(p: Palette, connected: bool) -> Element<'static, Message> {
     let dot = components::status_dot(p, connected);
 
-    let label = if connected {
-        "connected"
-    } else {
-        "disconected"
-    };
-
-    if size == WidgetSize::Small {
-        row![dot].spacing(8).align_y(Alignment::Center).into()
-    } else {
-        row![
-            dot,
-            text(label)
-                .size(size.detail_font())
-                .style(move |_: &iced::Theme| iced::widget::text::Style {
-                    color: Some(if connected { p.text_dim } else { p.danger })
-                }),
-        ]
-        .spacing(8)
-        .align_y(Alignment::Center)
-        .into()
-    }
+    row![dot].spacing(8).align_y(Alignment::End).into()
 }
 
 fn pulse_border(p: Palette, pulse: f32) -> iced::Color {
@@ -67,28 +47,29 @@ pub fn view(
     p: Palette,
     connected: bool,
     update: bool,
-    size: crate::widget_size::WidgetSize,
+    widget_settings: crate::config::WidgetSettings,
 ) -> Element<'_, Message> {
     let (friendly, main_opt, detail) = format_main_value(state);
-    let update_icon: Element<Message> = if update {
-        mouse_area(components::dimmed(
-            '⤓',
-            crate::theme::Palette {
-                text_dim: iced::Color::from_rgb8(255, 0, 0),
-                ..p
-            },
-        ))
+
+    let update_button = components::icon_button(
+        crate::ui::icon::Icon::Download,
+        components::tooltip_message("Update available", crate::ui::theme::MessageType::Error, p),
+        Some(p.danger),
+        Some(widget_settings.widget_size.title_font()),
+        Message::OpenSettingsTo(crate::ui::settings::SettingsPage::Updates),
+        p,
+    );
+
+    let update_icon: Element<Message> = mouse_area(update_button)
         .on_press(Message::OpenReleaseNotes)
         .interaction(iced::mouse::Interaction::Pointer)
-        .into()
-    } else {
-        components::dimmed("", p).into()
-    };
-    let title_text = if let Some(name) = friendly {
+        .into();
+
+    let mut title_text = if let Some(name) = friendly {
         row![
             column![
                 text(name)
-                    .size(size.title_font())
+                    .size(widget_settings.widget_size.title_font())
                     .style(move |_: &iced::Theme| {
                         iced::widget::text::Style {
                             color: Some(p.text_secondary),
@@ -96,29 +77,37 @@ pub fn view(
                     }),
             ]
             .width(iced::Fill),
-            update_icon
         ]
     } else {
         row![
             text(pretty_name(&state.entity_id))
-                .size(size.title_font())
+                .size(widget_settings.widget_size.title_font())
                 .style(move |_: &iced::Theme| iced::widget::text::Style {
                     color: Some(p.text_secondary),
                 }),
-            update_icon
         ]
     };
 
+    if update {
+        title_text = title_text.push(update_icon)
+    }
+
     let main = main_opt.unwrap_or_else(|| "-".into());
-    let value_text = text(main)
-        .size(size.value_font())
+    let maybe_adapted_value = widget_settings.adaptive.adapted_value(&main);
+    let maybe_adaptet_font = widget_settings.adaptive.font_size(
+        widget_settings.widget_size.value_font(),
+        maybe_adapted_value.chars().count(),
+    );
+    let value_text = text(maybe_adapted_value)
+        .size(maybe_adaptet_font)
+        .wrapping(iced::widget::text::Wrapping::None)
         .style(move |_: &iced::Theme| iced::widget::text::Style {
             color: Some(p.text_primary),
         });
 
     let detail_line: Element<'static, Message> = if let Some(d) = detail {
         text(d)
-            .size(size.detail_font())
+            .size(widget_settings.widget_size.detail_font())
             .style(move |_: &iced::Theme| iced::widget::text::Style {
                 color: Some(p.text_dim),
             })
@@ -127,24 +116,36 @@ pub fn view(
         space().height(0).width(0).into()
     };
 
+    let disconnected_text =
+        components::error_message("You are disconected from Home Assistant!", p);
+
     let ring = pulse_border(p, state.pulse);
 
     let inner = column![
         title_text,
-        space().height(size.title_value_gap()),
-        value_text,
-        space().height(size.value_detail_gap()),
+        space().height(widget_settings.widget_size.title_value_gap()),
         {
-            if size == WidgetSize::Small {
+            if !connected {
+                disconnected_text
+            } else {
+                value_text.into()
+            }
+        },
+        space().height(widget_settings.widget_size.value_detail_gap()),
+        {
+            if widget_settings.widget_size == WidgetSize::Small
+                || !widget_settings.show_measurement_info
+            {
                 space().height(0).width(0).into()
             } else {
                 detail_line
             }
         },
-        status_line(p, connected, size),
+        status_line(p, connected),
     ]
     .spacing(0)
-    .width(Length::Fill);
+    .width(Length::Fill)
+    .height(Length::Fill);
 
     components::card_with_border(inner.into(), p, ring)
 }

--- a/src/ui/icon.rs
+++ b/src/ui/icon.rs
@@ -6,7 +6,7 @@
 // per-OS fallback to Segoe UI Emoji on Windows (colored emoji) vs Apple
 // Symbols on macOS (thin outline) vs whatever fontconfig resolves on Linux.
 
-use crate::ui::theme::{UiTheme, icon_text};
+use crate::{theme::Palette, ui::theme::icon_text};
 
 #[derive(Copy, Clone)]
 pub enum Icon {
@@ -33,10 +33,10 @@ impl Icon {
         }
     }
 
-    pub fn text<'a>(self, ui_theme: UiTheme) -> iced::widget::Text<'a> {
+    pub fn text<'a>(self, p: Palette) -> iced::widget::Text<'a> {
         iced::widget::text(self.glyph())
             .size(Self::ICON_SIZE)
             .font(Self::ICON_FONT)
-            .style(icon_text(ui_theme, 1.0))
+            .style(icon_text(p, 1.0))
     }
 }

--- a/src/ui/icon.rs
+++ b/src/ui/icon.rs
@@ -17,6 +17,7 @@ pub enum Icon {
     Close,
     Unknown,
     Refresh,
+    ExternalLink,
 }
 
 impl Icon {
@@ -32,6 +33,7 @@ impl Icon {
             Self::Close => '\u{e1b2}',
             Self::Unknown => '\u{e47b}',
             Self::Refresh => '\u{e144}',
+            Self::ExternalLink => '\u{e0b9}',
         }
     }
 

--- a/src/ui/icon.rs
+++ b/src/ui/icon.rs
@@ -16,6 +16,7 @@ pub enum Icon {
     Trash,
     Close,
     Unknown,
+    Refresh,
 }
 
 impl Icon {
@@ -30,6 +31,7 @@ impl Icon {
             Self::Trash => '\u{e18e}',
             Self::Close => '\u{e1b2}',
             Self::Unknown => '\u{e47b}',
+            Self::Refresh => '\u{e144}',
         }
     }
 

--- a/src/ui/release_notes.rs
+++ b/src/ui/release_notes.rs
@@ -2,13 +2,11 @@ use iced::widget::{column, container, markdown, mouse_area, row, text};
 use iced::{Alignment, Element, Length, window};
 
 use crate::app::{Message, Snapdash};
-use crate::theme::metric;
+use crate::theme::{metric, text_size};
 use crate::ui::components;
 use crate::ui::icon::Icon;
-use crate::ui::theme::UiTheme;
 
 pub fn view<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
-    let ui_theme = UiTheme::from(&snap.theme);
     let p = snap.theme.palette();
 
     let title_text = match &snap.update.latest_release {
@@ -23,9 +21,9 @@ pub fn view<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
     let title_bar: Element<Message> = row![
         mouse_area(container(title_widget).width(Length::Fill).padding([4, 0]))
             .on_press(Message::StartDrag(id)),
-        components::pill_button(
-            Icon::Close.text(ui_theme),
-            p,
+        components::pill_button_with(
+            Icon::Close.text(p),
+            components::ButtonVisual::pill(p),
             Some(Message::CloseWindow(id))
         ),
     ]
@@ -72,7 +70,7 @@ pub fn view<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
 
     let md_inner: Element<Message> = markdown::view(
         &snap.update.release_notes_items,
-        markdown::Settings::with_text_size(13, md_style),
+        markdown::Settings::with_text_size(text_size::NORMAL, md_style),
     )
     .map(Message::OpenUrl);
 

--- a/src/ui/settings/chrome.rs
+++ b/src/ui/settings/chrome.rs
@@ -7,45 +7,19 @@ use iced::widget::{container, mouse_area, row};
 use iced::{Element, Length, mouse, window};
 
 use crate::app::{Message, Snapdash};
-use crate::theme::metric;
+use crate::theme::{metric, text_size};
 use crate::ui::components;
 use crate::ui::icon::Icon;
-use crate::ui::theme::UiTheme;
 use crate::ui::update_view;
 
 pub fn title_bar<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
     let p = snap.theme.palette();
 
-    let ui_theme = UiTheme::from(&snap.theme);
-
     let update_badge: Element<Message> = if snap.update.is_available() {
-        // let inner = iced::widget::row![
-        //     Icon::Download.text(ui_theme).size(14).color(p.danger),
-        //     iced::widget::text("Update Available")
-        //         .size(12)
-        //         .style(move |_: &iced::Theme| iced::widget::text::Style {
-        //             color: Some(p.danger),
-        //         })
-        // ]
-        // .spacing(6)
-        // .align_y(iced::Alignment::Center);
-
-        // components::pill_button_with(
-        //     inner,
-        //     components::ButtonVisual::pill(p)
-        //         .bg_hovered(p.card_2)
-        //         .bg(iced::Color::TRANSPARENT)
-        //         .border(p.danger),
-        //     Some(Message::SettingsPageSelected(
-        //         crate::ui::settings::SettingsPage::Updates,
-        //     )),
-        // )
-        // .into()
-
         mouse_area(components::badge_with_icon(
             "Update Available",
             Icon::Download,
-            ui_theme,
+            p,
         ))
         .on_press(Message::OpenReleaseNotes)
         .interaction(mouse::Interaction::Pointer)
@@ -62,9 +36,9 @@ pub fn title_bar<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message>
         )
         .on_press(Message::StartDrag(id)),
         update_badge,
-        components::pill_button(
-            Icon::Close.text(ui_theme),
-            p,
+        components::pill_button_with(
+            Icon::Close.text(p).size(text_size::NORMAL),
+            components::ButtonVisual::pill(p),
             Some(Message::CloseWindow(id))
         ),
     ]
@@ -75,7 +49,6 @@ pub fn title_bar<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message>
 
 pub fn footer<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
-    let ui_theme = UiTheme::from(&snap.theme);
 
     let status: Element<Message> = if !snap.status.is_empty() {
         components::dimmed(snap.status.clone(), p).into()
@@ -87,7 +60,7 @@ pub fn footer<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let save_btn = components::primary_button("Save", p, Some(Message::SavePressed));
 
     let quit_btn = components::pill_button("Quit", p, Some(Message::QuitApp));
-    let update_icon = update_view::status_icon(snap.update.state, ui_theme, p);
+    let update_icon = update_view::status_icon(snap.update.state, p);
     let update_icon: Element<Message> = if snap.update.is_available() {
         iced::widget::mouse_area(update_icon)
             .on_press(Message::SettingsPageSelected(
@@ -118,51 +91,3 @@ pub fn footer<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     .align_y(iced::Alignment::Center)
     .into()
 }
-
-// pub fn save_row<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
-//     let p = snap.theme.palette();
-//
-//     row![
-//         components::pill_button("Save", p, Some(Message::SavePressed)),
-//         iced::widget::space().width(Length::Fill),
-//         components::pill_button("Quit App", p, Some(Message::QuitApp)),
-//     ]
-//     .spacing(metric::GAP)
-//     .align_y(iced::Alignment::Center)
-//     .into()
-// }
-//
-// pub fn status_row<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
-//     let p = snap.theme.palette();
-//     let ui_theme = UiTheme::from(&snap.theme);
-//
-//     let status: Element<Message> = if !snap.status.is_empty() {
-//         components::dimmed(snap.status.clone(), p).into()
-//     } else {
-//         components::dimmed("Status", p).into()
-//     };
-//
-//     let update_icon = update_view::status_icon(snap.update.state, ui_theme, p);
-//     let update_icon: Element<Message> = if snap.update.is_available() {
-//         mouse_area(update_icon)
-//             .on_press(Message::OpenReleaseNotes)
-//             .interaction(mouse::Interaction::Pointer)
-//             .into()
-//     } else {
-//         update_icon.into()
-//     };
-
-//     let version: Element<Message> = row![
-//         components::dimmed(format!("version: {} ", update::CURRENT_VERSION), p),
-//         update_icon
-//     ]
-//     .padding([4, 0])
-//     .into();
-//
-//     row![
-//         column![status].width(Length::Fill),
-//         column![version].align_x(iced::Alignment::End)
-//     ]
-//     .width(Length::Fill)
-//     .into()
-// }

--- a/src/ui/settings/pages/advanced.rs
+++ b/src/ui/settings/pages/advanced.rs
@@ -1,62 +1,42 @@
-use iced::widget::{column, row};
-use iced::{Element, Length};
+use iced::Element;
 
 use crate::app::{Message, Snapdash};
-use crate::theme::metric;
-use crate::ui::components;
+use crate::ui::components::ButtonType;
+use crate::ui::components::settings_components::{item_with_button, page};
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
 
-    let config_row = row![
-        column![
-            components::body("Edit config.json", p),
-            components::helper("Open the JSON config in your default editor.", p,),
-        ]
-        .width(iced::Length::Fill),
-        components::pill_button("Open", p, Some(Message::OpenConfigFile)),
-    ]
-    .align_y(iced::Alignment::Center)
-    .spacing(metric::GAP);
-
-    let log_row = row![
-        column![
-            components::body("Open log directory", p),
-            components::helper("Browse runtime logs in your file manager.", p,),
-        ]
-        .width(iced::Length::Fill),
-        components::pill_button("Open", p, Some(Message::OpenLogFile)),
-    ]
-    .align_y(iced::Alignment::Center)
-    .spacing(metric::GAP);
-
-    let reset_row = row![
-        column![
-            components::body("Reset to defaults", p),
-            components::helper(
-                "Wipes HA URL, theme and selected sensors. The HA token in the keychain is not affected.",
+    page(
+        "Advanced",
+        [
+            item_with_button(
+                "Edit config.json",
+                Some("Open the JSON config in your default editor."),
+                "Open",
+                Some(Message::OpenConfigFile),
+                ButtonType::PILL,
                 p,
             ),
-        ]
-        .width(iced::Length::Fill),
-        components::pill_button_with("Reset", components::ButtonVisual::pill(p).bg(p.danger).bg_hovered(p.danger), Some(Message::ResetConfig)),
-    ]
-    .align_y(iced::Alignment::Center)
-    .spacing(metric::GAP);
-
-    let body = column![
-        config_row,
-        iced::widget::space().height(metric::GAP),
-        log_row,
-        iced::widget::space().height(metric::GAP),
-        reset_row,
-    ]
-    .spacing(metric::GAP);
-    column![
-        components::title(snap.settings_page.label(), p),
-        components::subcard(body.into(), p)
-    ]
-    .spacing(metric::PAD)
-    .width(Length::Fill)
-    .into()
+            item_with_button(
+                "Open log directory",
+                Some("Browse runtime logs in your file manager."),
+                "Open",
+                Some(Message::OpenLogFile),
+                ButtonType::PILL,
+                p,
+            ),
+            item_with_button(
+                "Reset to defaults",
+                Some(
+                    "Wipes HA URL, theme and selected sensors. The HA token in the keychain is not affected.",
+                ),
+                "Reset",
+                Some(Message::ResetConfig),
+                ButtonType::DANGER,
+                p,
+            ),
+        ],
+        p,
+    )
 }

--- a/src/ui/settings/pages/advanced.rs
+++ b/src/ui/settings/pages/advanced.rs
@@ -2,38 +2,66 @@ use iced::Element;
 
 use crate::app::{Message, Snapdash};
 use crate::ui::components::ButtonType;
-use crate::ui::components::settings_components::{item_with_button, page};
+use crate::ui::components::settings_components::{
+    item_with_button, item_with_icon_button, page_with_sections, section,
+};
+use crate::ui::icon;
+use crate::{helpers, logger};
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
 
-    page(
+    let size = logger::get_log_size().unwrap_or(0);
+    let log_size_helper = format!(
+        "Truncate the runtime log file. Current size is {}",
+        helpers::humanize_bytes(size)
+    );
+
+    page_with_sections(
         "Advanced",
         [
-            item_with_button(
-                "Edit config.json",
-                Some("Open the JSON config in your default editor."),
-                "Open",
-                Some(Message::OpenConfigFile),
-                ButtonType::PILL,
+            // Edit section
+            section(
+                [item_with_icon_button(
+                    "Edit config.json",
+                    Some("Open the JSON config in your default editor."),
+                    icon::Icon::ExternalLink,
+                    Message::OpenConfigFile,
+                    p,
+                )],
                 p,
             ),
-            item_with_button(
-                "Open log directory",
-                Some("Browse runtime logs in your file manager."),
-                "Open",
-                Some(Message::OpenLogFile),
-                ButtonType::PILL,
+            // Log section
+            section(
+                [
+                    item_with_icon_button(
+                        "Open log directory",
+                        Some("Browse runtime logs in your file manager."),
+                        icon::Icon::ExternalLink,
+                        Message::OpenLogFile,
+                        p,
+                    ),
+                    item_with_icon_button(
+                        "Clear log file",
+                        Some(log_size_helper),
+                        icon::Icon::Refresh,
+                        Message::TruncateLogFile,
+                        p,
+                    ),
+                ],
                 p,
             ),
-            item_with_button(
-                "Reset to defaults",
-                Some(
-                    "Wipes HA URL, theme and selected sensors. The HA token in the keychain is not affected.",
-                ),
-                "Reset",
-                Some(Message::ResetConfig),
-                ButtonType::DANGER,
+            section(
+                [item_with_button(
+                    "Reset to defaults",
+                    Some(
+                        "Wipes HA URL, theme and selected sensors. The HA token in the keychain is not affected.",
+                    ),
+                    "Reset",
+                    Some(Message::ResetConfig),
+                    ButtonType::DANGER,
+                    p,
+                )],
                 p,
             ),
         ],

--- a/src/ui/settings/pages/appearance.rs
+++ b/src/ui/settings/pages/appearance.rs
@@ -1,46 +1,32 @@
-use iced::widget::{column, row};
-use iced::{Element, Length};
+use iced::Element;
 
 use crate::app::{Message, Snapdash};
-use crate::theme::metric;
-use crate::ui::components::{self, body_with_helper};
+use crate::ui::components::settings_components;
 use crate::widget_size::WidgetSize;
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
 
-    let theme_picker: Element<Message> =
-        components::themepicker(snap.theme_options.clone(), snap.theme, p).into();
-
-    let theme_row: Element<Message> = row![
-        components::body("Theme", p),
-        iced::widget::space().width(iced::Length::Fill),
-        theme_picker
-    ]
-    .align_y(iced::Alignment::Center)
-    .into();
-
-    let size_picker: Element<Message> = components::picker(
-        WidgetSize::ALL.to_vec(),
-        snap.config.widget_size,
-        Message::WidgetSizeChanged,
+    settings_components::page(
+        "Appearance",
+        [
+            settings_components::item_with_picker(
+                "Theme",
+                None,
+                snap.theme_options.clone(),
+                snap.theme,
+                Message::ThemeSelected,
+                p,
+            ),
+            settings_components::item_with_picker(
+                "Widget size",
+                Some("Affects new and currently opened widgets"),
+                WidgetSize::ALL.to_vec(),
+                snap.config.widget_size,
+                Message::WidgetSizeChanged,
+                p,
+            ),
+        ],
         p,
     )
-    .into();
-
-    let size_row: Element<Message> = row![
-        body_with_helper("Widget size", "Affects new and currently opened widgets", p),
-        iced::widget::space().width(Length::Fill),
-        size_picker
-    ]
-    .align_y(iced::Alignment::Center)
-    .spacing(metric::GAP)
-    .into();
-
-    let body: Element<Message> = column![theme_row, size_row].spacing(metric::GAP).into();
-
-    column![components::title(snap.settings_page.label(), p), body]
-        .spacing(metric::PAD)
-        .width(Length::Fill)
-        .into()
 }

--- a/src/ui/settings/pages/appearance.rs
+++ b/src/ui/settings/pages/appearance.rs
@@ -7,23 +7,54 @@ use crate::widget_size::WidgetSize;
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
 
-    settings_components::page(
+    settings_components::page_with_sections(
         "Appearance",
         [
-            settings_components::item_with_picker(
-                "Theme",
-                None,
-                snap.theme_options.clone(),
-                snap.theme,
-                Message::ThemeSelected,
+            // Theme section
+            settings_components::section(
+                [settings_components::item_with_picker(
+                    "Theme",
+                    None,
+                    snap.theme_options.clone(),
+                    snap.theme,
+                    Message::ThemeSelected,
+                    p,
+                )],
                 p,
             ),
-            settings_components::item_with_picker(
-                "Widget size",
-                Some("Affects new and currently opened widgets"),
-                WidgetSize::ALL.to_vec(),
-                snap.config.widget_size,
-                Message::WidgetSizeChanged,
+            // Widget section
+            settings_components::section(
+                [
+                    settings_components::item_with_picker(
+                        "Widget size",
+                        Some("Affects new and currently opened widgets"),
+                        WidgetSize::ALL.to_vec(),
+                        snap.config.widget_settings.widget_size,
+                        Message::WidgetSizeChanged,
+                        p,
+                    ),
+                    settings_components::item_with_toggle(
+                        "Adaptive font size",
+                        Some("Scale font on long values so they fit on one line."),
+                        snap.config.widget_settings.adaptive.adaptive_font,
+                        Message::AdaptiveFontChanged,
+                        p,
+                    ),
+                    settings_components::item_with_toggle(
+                        "Smart number formatting",
+                        Some("Compress large values - 1234567 W -> 1.23 MW"),
+                        snap.config.widget_settings.adaptive.adaptive_value,
+                        Message::AdaptiveValueChanged,
+                        p,
+                    ),
+                    settings_components::item_with_toggle(
+                        "Show status bar",
+                        None,
+                        snap.config.widget_settings.show_measurement_info,
+                        Message::ShowMeasurementInfoChanged,
+                        p,
+                    ),
+                ],
                 p,
             ),
         ],

--- a/src/ui/settings/pages/connection.rs
+++ b/src/ui/settings/pages/connection.rs
@@ -1,47 +1,48 @@
-use iced::widget::{column, row};
-use iced::{Element, Length};
+use iced::Element;
 
 use crate::app::{Message, Snapdash};
-use crate::theme::metric;
-use crate::ui::components;
+use crate::theme::text_size;
+use crate::ui::components::{self, settings_components};
 use crate::ui::icon::Icon;
-use crate::ui::theme::UiTheme;
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
-    let ui_theme = UiTheme::from(&snap.theme);
 
-    let url: Element<Message> = components::mac_input("Home Assistant URL", &snap.config.ha_url, p)
-        .on_input(Message::HaUrlChanged)
+    let token_item = if !snap.config.ha_token_present {
+        settings_components::item_with_input(
+            "Token",
+            Some("Enter your Home Assistant`s Long-lived token"),
+            "Long-Lived Token belong here ...",
+            &snap.ha.token_draft,
+            Message::HaTokenDraftChanged,
+            Some(Message::SavePressed),
+            p,
+        )
+    } else {
+        let title_element = components::success_message("Token is stored in the key-chain", p);
+        let action_element = components::danger_button_with(
+            Icon::Trash.text(p).size(text_size::LARGE).into(),
+            p,
+            Some(Message::HaTokenDelete),
+        )
         .into();
-
-    let placeholder = match snap.config.ha_token_present {
-        true => "Token stored in key-chain",
-        _ => "Enter your token ...",
+        settings_components::item_with_element(title_element, action_element)
     };
 
-    let token: Element<Message> = components::mac_input(placeholder, &snap.ha.token_draft, p)
-        .on_input(Message::HaTokenDraftChanged)
-        .into();
-
-    let token_delete: Element<Message> =
-        components::pill_button(Icon::Trash.text(ui_theme), p, Some(Message::HaTokenDelete)).into();
-
-    let body = components::subcard(
-        column![
-            components::section("Home Assistant", p),
-            url,
-            row![token, token_delete]
-                .spacing(metric::GAP)
-                .align_y(iced::Alignment::Center)
-        ]
-        .spacing(metric::GAP)
-        .into(),
+    settings_components::page(
+        "Connection",
+        [
+            settings_components::item_with_input(
+                "Home Assistant URL",
+                Some("Enter fully qualified URL or IP (with http or https prefix)."),
+                "Enter your Home Assistant's URL or IP address ...",
+                &snap.config.ha_url,
+                Message::HaUrlChanged,
+                Some(Message::SavePressed),
+                p,
+            ),
+            token_item,
+        ],
         p,
-    );
-
-    column![components::title(snap.settings_page.label(), p), body]
-        .width(Length::Fill)
-        .spacing(metric::GAP)
-        .into()
+    )
 }

--- a/src/ui/settings/pages/connection.rs
+++ b/src/ui/settings/pages/connection.rs
@@ -1,32 +1,66 @@
 use iced::Element;
 
 use crate::app::{Message, Snapdash};
+use crate::ha::token::TokenPresence;
 use crate::theme::text_size;
-use crate::ui::components::{self, settings_components};
+use crate::ui::components::{self, ButtonVisual, settings_components};
 use crate::ui::icon::Icon;
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
 
-    let token_item = if !snap.config.ha_token_present {
-        settings_components::item_with_input(
+    let token_item = match &snap.token_presence {
+        TokenPresence::Missing => settings_components::item_with_input(
             "Token",
             Some("Enter your Home Assistant`s Long-lived token"),
-            "Long-Lived Token belong here ...",
+            "Long-Lived Token belongs here ...",
             &snap.ha.token_draft,
             Message::HaTokenDraftChanged,
             Some(Message::SavePressed),
             p,
-        )
-    } else {
-        let title_element = components::success_message("Token is stored in the key-chain", p);
-        let action_element = components::danger_button_with(
-            Icon::Trash.text(p).size(text_size::LARGE).into(),
-            p,
-            Some(Message::HaTokenDelete),
-        )
-        .into();
-        settings_components::item_with_element(title_element, action_element)
+        ),
+        TokenPresence::Present if snap.ha.auth_failed => {
+            let title_element = components::error_message(
+                "Token possibly invalid. HA rejected authorization with AuthFailed.",
+                p,
+            );
+            let action_element = components::danger_button_with(
+                Icon::Trash.text(p).size(text_size::LARGE).into(),
+                p,
+                Some(Message::HaTokenDelete),
+            )
+            .into();
+            settings_components::item_with_element(title_element, action_element)
+        }
+        TokenPresence::Present => {
+            let title_element = components::success_message("Token is stored in the key-chain", p);
+            let action_element = components::danger_button_with(
+                Icon::Trash.text(p).size(text_size::LARGE).into(),
+                p,
+                Some(Message::HaTokenDelete),
+            )
+            .into();
+            settings_components::item_with_element(title_element, action_element)
+        }
+        TokenPresence::AccessFailed(..) => {
+            let title_element = components::error_message("Access to key-chain was denied.", p);
+            let action_element = components::pill_button_with(
+                Icon::Refresh.text(p).size(text_size::LARGE),
+                ButtonVisual::pill(p),
+                Some(Message::RetryHaTokenPresence),
+            )
+            .into();
+            settings_components::item_with_element(title_element, action_element)
+        }
+        TokenPresence::Checking | TokenPresence::Unchecked => {
+            settings_components::item_with_icon_button(
+                "Checking token",
+                Some("Trying to access your OS key-chain"),
+                Icon::Refresh,
+                Message::RetryHaTokenPresence,
+                p,
+            )
+        }
     };
 
     settings_components::page(

--- a/src/ui/settings/pages/general.rs
+++ b/src/ui/settings/pages/general.rs
@@ -68,6 +68,43 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
 
     let stats = components::subcard(column![ha_row, sensors_row].spacing(metric::GAP).into(), p);
 
+    let macos_hint: Option<Element<Message>> = if cfg!(target_os = "macos") && snap.config.autostart
+    {
+        Some(
+            components::helper(
+                "macOS may ask you to allow Snapdash in System Settings → \
+                         Login Items the first time. After approval, autostart \
+                         persists across reboots.",
+                p,
+            )
+            .into(),
+        )
+    } else {
+        None
+    };
+
+    let autostart_row: Element<Message> = row![
+        components::body_with_helper(
+            "Start at login",
+            "Launch Snapdash automatically when you log in your computer.",
+            p
+        ),
+        components::toggler(snap.config.autostart, Message::AutostartChanged, p),
+    ]
+    .align_y(iced::Alignment::Center)
+    .spacing(metric::GAP)
+    .into();
+
+    let mut behavior_inner =
+        iced::widget::column![components::section("Behavior", p), autostart_row]
+            .spacing(metric::GAP);
+
+    if let Some(hint) = macos_hint {
+        behavior_inner = behavior_inner.push(hint);
+    }
+
+    let behavior = components::subcard(behavior_inner.into(), p);
+
     let actions = components::subcard(
         column![action_config, action_logs]
             .spacing(metric::GAP)
@@ -80,6 +117,7 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
         hero,
         iced::widget::space().height(metric::PAD),
         stats,
+        behavior,
         actions,
     ]
     .spacing(metric::PAD)

--- a/src/ui/settings/pages/general.rs
+++ b/src/ui/settings/pages/general.rs
@@ -1,29 +1,20 @@
-use iced::widget::{column, row};
+use iced::widget::column;
 use iced::{Element, Length};
 
 use crate::app::{Message, Snapdash};
 use crate::theme::metric;
-use crate::ui::components;
+use crate::ui::components::settings_components::item_with_status;
+use crate::ui::components::{self, settings_components};
 use crate::ui::icon::Icon;
-use crate::ui::theme::UiTheme;
 use crate::update;
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
-    let ui_theme = UiTheme::from(&snap.theme);
 
     // Hero
     let hero = column![
-        iced::widget::text("Snapdash")
-            .size(28)
-            .style(move |_: &iced::Theme| iced::widget::text::Style {
-                color: Some(p.text_primary),
-            }),
-        iced::widget::text(format!("Version {}", update::CURRENT_VERSION))
-            .size(13)
-            .style(move |_: &iced::Theme| iced::widget::text::Style {
-                color: Some(p.text_secondary),
-            }),
+        components::title("Snapdash", p),
+        components::label(format!("Version {}", update::CURRENT_VERSION), p)
     ]
     .spacing(4);
 
@@ -42,35 +33,35 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
         p.text_dim
     };
 
-    let ha_row = stat_row("Home Assistant", ha_status_text, ha_color, p);
-    let sensors_row = stat_row(
-        "Selected senors",
+    let ha_row = settings_components::item_with_element(
+        components::body("Home Assistant", p).into(),
+        iced::widget::text(ha_status_text)
+            .size(13)
+            .style(move |_: &iced::Theme| iced::widget::text::Style {
+                color: Some(ha_color),
+            })
+            .into(),
+    );
+
+    let sensors_row = item_with_status(
+        "Selected sensors",
+        None,
         format!("{}", snap.selected_widgets.len()),
-        p.text_body,
         p,
     );
-    let action_config = action_link(
-        "Edit configuration",
-        "config.json",
-        Icon::Gear,
-        Message::OpenConfigFile,
-        ui_theme,
-        p,
-    );
-    let action_logs = action_link(
-        "Open log directory",
-        "Browse runtime logs",
-        Icon::Download,
-        Message::OpenLogFile,
-        ui_theme,
-        p,
-    );
+    let stats = settings_components::section([ha_row, sensors_row], p);
 
-    let stats = components::subcard(column![ha_row, sensors_row].spacing(metric::GAP).into(), p);
+    // Behavior section
+    let mut behav_items: Vec<Element<Message>> = vec![settings_components::item_with_toggle(
+        "Start at login",
+        Some("Launch Snapdash automatically when you log into your computer."),
+        snap.config.autostart,
+        Message::AutostartChanged,
+        p,
+    )];
 
-    let macos_hint: Option<Element<Message>> = if cfg!(target_os = "macos") && snap.config.autostart
-    {
-        Some(
+    if cfg!(target_os = "macos") && snap.config.autostart {
+        behav_items.push(
             components::helper(
                 "macOS may ask you to allow Snapdash in System Settings → \
                          Login Items the first time. After approval, autostart \
@@ -78,37 +69,28 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
                 p,
             )
             .into(),
-        )
-    } else {
-        None
-    };
-
-    let autostart_row: Element<Message> = row![
-        components::body_with_helper(
-            "Start at login",
-            "Launch Snapdash automatically when you log in your computer.",
-            p
-        ),
-        components::toggler(snap.config.autostart, Message::AutostartChanged, p),
-    ]
-    .align_y(iced::Alignment::Center)
-    .spacing(metric::GAP)
-    .into();
-
-    let mut behavior_inner =
-        iced::widget::column![components::section("Behavior", p), autostart_row]
-            .spacing(metric::GAP);
-
-    if let Some(hint) = macos_hint {
-        behavior_inner = behavior_inner.push(hint);
+        );
     }
 
-    let behavior = components::subcard(behavior_inner.into(), p);
+    let behav = settings_components::section(behav_items, p);
 
-    let actions = components::subcard(
-        column![action_config, action_logs]
-            .spacing(metric::GAP)
-            .into(),
+    let actions = settings_components::section(
+        [
+            settings_components::item_with_icon_button(
+                "Edit configuration",
+                Some("Open config.json in your default editor."),
+                Icon::Gear,
+                Message::OpenConfigFile,
+                p,
+            ),
+            settings_components::item_with_icon_button(
+                "Open log directory",
+                Some("Browse runtime logs in your file manager."),
+                Icon::Download,
+                Message::OpenLogFile,
+                p,
+            ),
+        ],
         p,
     );
 
@@ -117,73 +99,10 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
         hero,
         iced::widget::space().height(metric::PAD),
         stats,
-        behavior,
+        behav,
         actions,
     ]
     .spacing(metric::PAD)
     .width(Length::Fill)
-    .into()
-}
-
-fn stat_row(
-    label: &'static str,
-    value: String,
-    value_color: iced::Color,
-    p: crate::theme::Palette,
-) -> Element<'static, Message> {
-    row![
-        iced::widget::text(label)
-            .size(13)
-            .style(move |_: &iced::Theme| {
-                iced::widget::text::Style {
-                    color: Some(p.text_dim),
-                }
-            }),
-        iced::widget::space().width(Length::Fill),
-        iced::widget::text(value)
-            .size(11)
-            .style(move |_: &iced::Theme| {
-                iced::widget::text::Style {
-                    color: Some(value_color),
-                }
-            }),
-    ]
-    .align_y(iced::Alignment::Center)
-    .into()
-}
-
-fn action_link<'a>(
-    label: &'static str,
-    helper: &'static str,
-    icon: Icon,
-    msg: Message,
-    ui_theme: UiTheme,
-    p: crate::theme::Palette,
-) -> Element<'a, Message> {
-    row![
-        column![
-            iced::widget::text(label)
-                .size(13)
-                .style(move |_: &iced::Theme| {
-                    iced::widget::text::Style {
-                        color: Some(p.text_body),
-                    }
-                }),
-            iced::widget::text(helper)
-                .size(11)
-                .style(move |_: &iced::Theme| {
-                    iced::widget::text::Style {
-                        color: Some(p.text_dim),
-                    }
-                }),
-        ]
-        .spacing(2)
-        .width(Length::Fill),
-        iced::widget::mouse_area(icon.text(ui_theme).size(14).color(p.text_dim),)
-            .on_press(msg)
-            .interaction(iced::mouse::Interaction::Pointer)
-    ]
-    .align_y(iced::Alignment::Center)
-    .spacing(metric::GAP)
     .into()
 }

--- a/src/ui/settings/pages/sensors.rs
+++ b/src/ui/settings/pages/sensors.rs
@@ -32,21 +32,18 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
         p,
     );
 
-    let body: Element<'a, Message> =
-        //column![
-             row![
-                container(available_panel).width(Length::FillPortion(1)),
-                container(selected_panel).width(Length::FillPortion(1)),
-            ]
-            .spacing(metric::GAP)
-            .align_y(iced::Alignment::Start)
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .into();
-
-    //.spacing(metric::GAP)
-    //.width(Length::Fill)
-    //.height(Length::Fill)
+    let body: Element<'a, Message> = components::subcard(
+        row![
+            container(available_panel).width(Length::FillPortion(1)),
+            container(selected_panel).width(Length::FillPortion(1)),
+        ]
+        .spacing(metric::GAP)
+        .align_y(iced::Alignment::Start)
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into(),
+        p,
+    );
 
     column![components::title(snap.settings_page.label(), p), body]
         .width(Length::Fill)

--- a/src/ui/settings/pages/updates.rs
+++ b/src/ui/settings/pages/updates.rs
@@ -4,13 +4,11 @@ use iced::{Element, Length};
 use crate::app::{Message, Snapdash};
 use crate::theme::metric;
 use crate::ui::components::{self, error_message, success_message};
-use crate::ui::theme::UiTheme;
 use crate::ui::update_view;
 use crate::update::{self, InstallProgress, UpdateState};
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     let p = snap.theme.palette();
-    let ui_theme = UiTheme::from(&snap.theme);
 
     let latest = match &snap.update.latest_release {
         Some(release) => release.tag_name.to_string(),
@@ -24,7 +22,7 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
     };
 
     let status_row = row![
-        update_view::status_icon(snap.update.state, ui_theme, p),
+        update_view::status_icon(snap.update.state, p),
         components::label(status_text, p),
     ]
     .spacing(metric::GAP)

--- a/src/ui/settings/sidebar.rs
+++ b/src/ui/settings/sidebar.rs
@@ -3,7 +3,7 @@ use iced::widget::{Button, button, column, text};
 use iced::{Background, Border, Color, Element, Length};
 
 use crate::app::{Message, Snapdash};
-use crate::theme::{Palette, metric};
+use crate::theme::{Palette, metric, text_size};
 
 use super::SettingsPage;
 
@@ -30,7 +30,7 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
 }
 
 fn nav_item(page: SettingsPage, is_active: bool, p: Palette) -> Button<'static, Message> {
-    button(text(page.label()).size(13))
+    button(text(page.label()).size(text_size::NORMAL))
         .style(move |_theme, status| {
             let bg = if is_active {
                 p.accent_tint

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,4 +1,4 @@
-use crate::theme::ThemeKind;
+use crate::theme::{Palette, ThemeKind};
 use iced::{Color, Theme};
 
 #[derive(Clone, Copy)]
@@ -23,10 +23,9 @@ impl From<&ThemeKind> for UiTheme {
 
 /// Styl pro "ikonové" tlačítko v pravém horním rohu (gear apod.)
 pub fn icon_button<'a>(
-    ui_theme: UiTheme,
+    p: Palette,
     alpha: f32,
 ) -> impl Fn(&Theme, iced::widget::button::Status) -> iced::widget::button::Style + 'a {
-    let p = ui_theme.palette;
     move |_theme: &Theme, _status: iced::widget::button::Status| iced::widget::button::Style {
         background: None,
         border: iced::Border {
@@ -44,11 +43,7 @@ pub fn icon_button<'a>(
 }
 
 /// Styl pro text uvnitř ikonového tlačítka (pokud ho chceš zdůraznit jinak než default text)
-pub fn icon_text<'a>(
-    ui_theme: UiTheme,
-    alpha: f32,
-) -> impl Fn(&Theme) -> iced::widget::text::Style + 'a {
-    let p = ui_theme.palette;
+pub fn icon_text<'a>(p: Palette, alpha: f32) -> impl Fn(&Theme) -> iced::widget::text::Style + 'a {
     move |_theme: &Theme| iced::widget::text::Style {
         color: Some(Color {
             a: alpha,

--- a/src/ui/update_view.rs
+++ b/src/ui/update_view.rs
@@ -4,7 +4,6 @@
 
 use crate::theme::Palette;
 use crate::ui::icon::Icon;
-use crate::ui::theme::UiTheme;
 use crate::update::UpdateState;
 
 const UPDATE_ICON_SIZE: f32 = 12.0;
@@ -12,16 +11,12 @@ const UPDATE_ICON_SIZE: f32 = 12.0;
 /// Glyph + color combo for the version-status indicator shown in the
 /// settings footer. Returned as `Text` so callers can still chain
 /// `.size()`, `.color()`, etc. to override the defaults.
-pub fn status_icon<'a>(
-    state: UpdateState,
-    ui_theme: UiTheme,
-    p: Palette,
-) -> iced::widget::Text<'a> {
+pub fn status_icon<'a>(state: UpdateState, p: Palette) -> iced::widget::Text<'a> {
     let (icon, color) = match state {
         UpdateState::Unknown => (Icon::Unknown, p.text_dim),
         UpdateState::UptoDate => (Icon::Check, p.success),
         UpdateState::UpdateAvailable => (Icon::Download, p.danger),
     };
 
-    icon.text(ui_theme).size(UPDATE_ICON_SIZE).color(color)
+    icon.text(p).size(UPDATE_ICON_SIZE).color(color)
 }

--- a/src/widget_size.rs
+++ b/src/widget_size.rs
@@ -4,6 +4,45 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::helpers;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Adaptive {
+    pub adaptive_font: bool,
+    pub adaptive_value: bool,
+}
+
+impl Adaptive {
+    /// Returns the font size value to use for the
+    /// given text lenght.
+    /// Shrink gracefully, so long values stays on one
+    /// line and don`t push the widget layout aroud.
+    pub fn font_size(self, base: f32, text_len: usize) -> f32 {
+        if !self.adaptive_font {
+            return base;
+        }
+
+        let factor = match text_len {
+            0..=9 => 1.0,
+            10 => 0.85,
+            11..=13 => 0.7,
+            _ => 0.55,
+        };
+        base * factor
+    }
+
+    /// Humanize a numeric value if self.adaptive_value is on.
+    /// TODO: implement compression (1234567 -> 1.23M).
+    /// For now passes the raw value.
+    pub fn adapted_value(self, raw: &str) -> String {
+        if !self.adaptive_value {
+            return raw.to_string();
+        }
+
+        helpers::humanize_magnitude(raw)
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum WidgetSize {
     Small,
@@ -77,3 +116,6 @@ impl WidgetSize {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/widget_size/tests.rs
+++ b/src/widget_size/tests.rs
@@ -1,0 +1,35 @@
+use crate::helpers::humanize_magnitude;
+
+#[test]
+fn compresses_large_watts() {
+    assert_eq!(humanize_magnitude("1234567 W"), "1.23 MW");
+    assert_eq!(humanize_magnitude("5000 W"), "5.00 kW");
+}
+
+#[test]
+fn skips_in_range() {
+    assert_eq!(humanize_magnitude("500 W"), "500 W");
+    assert_eq!(humanize_magnitude("23 V"), "23 V");
+}
+
+#[test]
+fn skips_unsupported_units() {
+    assert_eq!(humanize_magnitude("23.5 °C"), "23.5 °C");
+    assert_eq!(humanize_magnitude("45.2 %"), "45.2 %");
+}
+
+#[test]
+fn skips_already_prefixed() {
+    assert_eq!(humanize_magnitude("1.5 kW"), "1.5 kW");
+}
+
+#[test]
+fn handles_non_numeric() {
+    assert_eq!(humanize_magnitude("On"), "On");
+    assert_eq!(humanize_magnitude(""), "");
+}
+
+#[test]
+fn compresses_small() {
+    assert_eq!(humanize_magnitude("0.0005 A"), "500.00 µA");
+}


### PR DESCRIPTION
## v0.0.6

Cuts from `dev` after autostart, clearer error surfacing, and the
adaptive widget-rendering work landed.

### Features

- **Start at login** (#56) — Settings → General gains a "Start at
  login" toggle. Snapdash registers itself with the OS autostart
  mechanism per platform: LaunchAgent on macOS, XDG `.desktop` file
  on Linux, registry entry on Windows. macOS first-launch shows an
  inline hint that System Settings may need to approve the entry.
- **Adaptive widget rendering** (#60) — long sensor values no longer
  wrap and break the widget layout. The value glyph shrinks
  proportionally for long strings, and an opt-in "Smart number
  formatting" toggle compresses large readings to SI prefixes
  (`1234567 W` → `1.23 MW`). Both flags default to ON;
  per-flag toggles live in Settings → Appearance.
- **Clear log** (#59) — Advanced page gets a destructive "Clear" button
  that truncates the runtime log without restarting. Useful before
  reproducing an issue so the resulting log only contains the
  relevant trace.

### Improvements

- **Live HA token state** (#58) — token presence is now tracked
  from the keychain at runtime instead of being mirrored from
  Config. Connection page always reflects the actual stored
  credential, so manual keychain changes (Keychain Access edits,
  another machine syncing) don't leave the UI stale.
- **Settings UI refactor** (#57) — typed text-size scale (title /
  body / helper / dim) and a `settings_components` builder family
  (`item_with_button` / `_toggle` / `_picker` / `_status` / `_input`).
  Pages compose declaratively from item lists instead of hand-rolled
  rows. Trims ~50% of the boilerplate in General/Advanced/Appearance
  and makes future settings additions a single line each.

### Auto-update notes

- macOS, Windows and Linux users on v0.0.5 should see this version
  via the in-app **Updates** tab — click *Install update* → *Restart now*
  and you're on 0.0.6.
- Existing `config.json` upgrades cleanly. New fields (`adaptive`,
  `autostart`) default to safe values via `#[serde(default)]`.

### Pull requests in this release

- #56 Start at login (cross-platform autostart)
- #57 Typed text sizes and declarative settings builders
- #58 Track HA token presence from keychain
- #59 Add clear log action and settings UI
- #60 Adaptive widget rendering (font + smart number formatting)
