### PR TITLE
fix(humanize): tighten milli threshold + trim trailing zeros

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -57,5 +57,4 @@ pub fn humanize_magnitude(raw: &str) -> String {
         .to_string();
 
     format!("{} {}{}", trimmed, prefix, unit)
-    
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -41,6 +41,10 @@ pub fn humanize_magnitude(raw: &str) -> String {
         (n / 1_000_000.0, "M")
     } else if abs >= 1_000.0 {
         (n / 1_000.0, "k")
+    } else if abs > 0.0 && abs < 1e-9 {
+        (n * 1e12, "p")
+    } else if abs > 0.0 && abs < 1e-6 {
+        (n * 1e9, "n")
     } else if abs > 0.0 && abs < 0.001 {
         (n * 1_000_000.0, "µ")
     } else if abs > 0.0 && abs < 0.01 {
@@ -51,10 +55,13 @@ pub fn humanize_magnitude(raw: &str) -> String {
     };
 
     let formated = format!("{:.2}", scaled);
-    let trimmed = formated
-        .trim_end_matches('0')
-        .trim_end_matches('.')
-        .to_string();
+    let trimmed = formated.trim_end_matches('0').trim_end_matches('.');
 
-    format!("{} {}{}", trimmed, prefix, unit)
+    let display = if trimmed.is_empty() || trimmed == "-" {
+        formated.as_str()
+    } else {
+        trimmed
+    };
+
+    format!("{} {}{}", display, prefix, unit)
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -43,12 +43,19 @@ pub fn humanize_magnitude(raw: &str) -> String {
         (n / 1_000.0, "k")
     } else if abs > 0.0 && abs < 0.001 {
         (n * 1_000_000.0, "µ")
-    } else if abs > 0.0 && abs < 1.0 {
+    } else if abs > 0.0 && abs < 0.01 {
         (n * 1_000.0, "m")
     } else {
         // 1..1000 range — no compression needed
         return raw.to_string();
     };
 
-    format!("{:.2} {}{}", scaled, prefix, unit)
+    let formated = format!("{:.2}", scaled);
+    let trimmed = formated
+        .trim_end_matches('0')
+        .trim_end_matches('.')
+        .to_string();
+
+    format!("{} {}{}", trimmed, prefix, unit)
+    
 }

--- a/src/widget_size/tests.rs
+++ b/src/widget_size/tests.rs
@@ -53,3 +53,16 @@ fn trims_trailing_zeros() {
     assert_eq!(humanize_magnitude("1500 W"), "1.5 kW");
     assert_eq!(humanize_magnitude("1230000 W"), "1.23 MW");
 }
+
+#[test]
+fn scales_into_nano_and_pico() {
+    assert_eq!(humanize_magnitude("0.000000001 A"), "1 nA"); // 1e-9
+    assert_eq!(humanize_magnitude("0.0000000005 A"), "500 pA"); // 5e-10
+    assert_eq!(humanize_magnitude("0.000000000001 A"), "1 pA"); // 1e-12
+}
+
+#[test]
+fn boundary_between_milli_and_micro() {
+    assert_eq!(humanize_magnitude("0.001 A"), "1 mA");
+    assert_eq!(humanize_magnitude("0.0001 A"), "100 µA"); // dropped from milli to micro
+}

--- a/src/widget_size/tests.rs
+++ b/src/widget_size/tests.rs
@@ -3,7 +3,7 @@ use crate::helpers::humanize_magnitude;
 #[test]
 fn compresses_large_watts() {
     assert_eq!(humanize_magnitude("1234567 W"), "1.23 MW");
-    assert_eq!(humanize_magnitude("5000 W"), "5.00 kW");
+    assert_eq!(humanize_magnitude("5000 W"), "5 kW");
 }
 
 #[test]
@@ -31,5 +31,25 @@ fn handles_non_numeric() {
 
 #[test]
 fn compresses_small() {
-    assert_eq!(humanize_magnitude("0.0005 A"), "500.00 µA");
+    assert_eq!(humanize_magnitude("0.0005 A"), "500 µA");
+}
+#[test]
+fn does_not_scale_moderately_small_values() {
+    assert_eq!(humanize_magnitude("0.1 A"), "0.1 A");
+    assert_eq!(humanize_magnitude("0.5 A"), "0.5 A");
+    assert_eq!(humanize_magnitude("0.05 A"), "0.05 A");
+}
+
+#[test]
+fn scales_truly_small_values() {
+    assert_eq!(humanize_magnitude("0.005 A"), "5 mA");
+    assert_eq!(humanize_magnitude("0.0001 A"), "100 µA");
+    assert_eq!(humanize_magnitude("0.0051 A"), "5.1 mA");
+}
+
+#[test]
+fn trims_trailing_zeros() {
+    assert_eq!(humanize_magnitude("5000 W"), "5 kW");
+    assert_eq!(humanize_magnitude("1500 W"), "1.5 kW");
+    assert_eq!(humanize_magnitude("1230000 W"), "1.23 MW");
 }


### PR DESCRIPTION
humanize_magnitude was scaling 0.1 A → 100.00 mA, which is longer and visually busier than the original — defeating the compression purpose. Two corrections:

- Milli prefix only fires below 0.01 (not 1.0). Values in 0.01..1 pass through unchanged so 0.1 A stays "0.1 A".
- Trim trailing zeros and the bare decimal point: "5.00 kW" → "5 kW", "1.50 kW" → "1.5 kW", "100.00 µA" → "100 µA". Cleaner display without sacrificing precision when it matters ("1.23 MW" still shows the digits).

Tests cover the three new cases.