### PR TITLE
Release 0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4557,7 +4557,7 @@ dependencies = [
 
 [[package]]
 name = "snapdash"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "auto-launch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snapdash"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 authors = ["Lukáš Svoboda <opensource@schizza.cz>"]
 license = "Apache-2.0"

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -37,15 +37,13 @@ impl Snapdash {
         // RedrawRequested fires on every frame, so we only subscribe while
         // an entity is animating its pulse. Otherwise we'd burn CPU on
         // idle widgets.
-        let redraw_events_needed = self.windows.values().any(|win| win.entity.pulse > 0.0);
 
-        let redraw_events = if redraw_events_needed {
-            iced::event::listen_raw(|event, _status, id| match event {
-                iced::Event::Window(window::Event::RedrawRequested(_)) => {
-                    Some(Message::WindowRedraw(id))
-                }
-                _ => None,
-            })
+        let animation_frames = if self
+            .windows
+            .values()
+            .any(|win| win.entity.pulse.is_animating())
+        {
+            iced::time::every(Duration::from_millis(16)).map(Message::AnimationFrame)
         } else {
             Subscription::none()
         };
@@ -94,7 +92,7 @@ impl Snapdash {
 
         Subscription::batch([
             window::close_events().map(Message::WindowClosed),
-            redraw_events,
+            animation_frames,
             move_events,
             keyboard_events,
             ha,

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -79,6 +79,7 @@ pub enum Message {
         id: window::Id,
         kind: WindowKind,
     },
+    AnimationFrame(iced::time::Instant),
 
     ThemeSelected(ThemeKind),
     SaveConfig,
@@ -98,7 +99,6 @@ pub enum Message {
     SavePressed,
     Saved,
     HaTokenDraftChanged(String),
-    WindowRedraw(window::Id),
     ConfigLoad(Result<Config, String>),
     StartDrag(window::Id),
     EntityHover {
@@ -222,18 +222,6 @@ impl Snapdash {
         self.rebuild_active_settings_sensors();
     }
 
-    fn handle_redraw_requested(&mut self, id: window::Id) {
-        let Some(window) = self.windows.get_mut(&id) else {
-            return;
-        };
-
-        if let WindowKind::Entity { .. } = window.kind
-            && window.entity.pulse > 0.0
-        {
-            window.entity.pulse = (window.entity.pulse - 0.08).max(0.0);
-        }
-    }
-
     fn set_window_entity_state(&mut self, entity_id: &str, new_state: &EntityState, pulse: bool) {
         let Some(window_id) = self.entity_windows.get(entity_id).copied() else {
             return;
@@ -247,7 +235,7 @@ impl Snapdash {
         window.entity.last = Some(new_state.clone());
 
         if pulse {
-            window.entity.pulse = 1.0;
+            window.entity.pulse.trigger();
         }
     }
 
@@ -263,13 +251,23 @@ impl Snapdash {
         self.rebuild_settings_sensors();
     }
 
+    fn display_signature(&self, st: &EntityState) -> (String, Option<String>) {
+        let formatted = crate::ui::format::format_entity_value(st);
+        (formatted.main, formatted.detail)
+    }
+
+    fn should_pulse(&self, old: Option<&EntityState>, new: &EntityState) -> bool {
+        match old {
+            Some(old) => self.display_signature(old) != self.display_signature(new),
+            None => true,
+        }
+    }
+
     fn apply_entity_state(&mut self, new_state: EntityState) {
         let entity_id = new_state.entity_id.clone();
 
-        self.set_window_entity_state(&entity_id, &new_state, true);
-
-        let should_refresh_settings = match self.ha.entities.get(&entity_id) {
-            None => true,
+        let (pulse, should_refresh_settings) = match self.ha.entities.get(&entity_id) {
+            None => (true, true),
             Some(old) => {
                 let old_is_sensor = old.entity_id.starts_with("sensor.");
                 let new_is_sensor = new_state.entity_id.starts_with("sensor.");
@@ -280,10 +278,14 @@ impl Snapdash {
                     .get("friendly_name")
                     .and_then(|v| v.as_str());
 
-                old_is_sensor != new_is_sensor || old_name != new_name
+                (
+                    self.should_pulse(Some(old), &new_state),
+                    old_is_sensor != new_is_sensor || old_name != new_name,
+                )
             }
         };
 
+        self.set_window_entity_state(&entity_id, &new_state, pulse);
         self.ha.entities.insert(entity_id, new_state);
 
         if should_refresh_settings {
@@ -966,11 +968,6 @@ impl Snapdash {
                 }
             }
 
-            Message::WindowRedraw(id) => {
-                self.handle_redraw_requested(id);
-                Task::none()
-            }
-
             Message::CheckForUpdate => {
                 Task::perform(update::get_latest_version(), Message::LastVersionChecked)
             }
@@ -1058,6 +1055,16 @@ impl Snapdash {
             Message::ShowMeasurementInfoChanged(b) => {
                 self.config.widget_settings.show_measurement_info = b;
                 self.save_config()
+            }
+
+            Message::AnimationFrame(now) => {
+                for window in self.windows.values_mut() {
+                    if let WindowKind::Entity { .. } = window.kind {
+                        window.entity.pulse.tick(now);
+                    }
+                }
+
+                Task::none()
             }
         }
     }

--- a/src/app/window.rs
+++ b/src/app/window.rs
@@ -9,6 +9,62 @@ use iced::window;
 
 use crate::ha::EntityState;
 
+#[derive(Debug, Clone)]
+pub struct PulseSpring {
+    value: f32,
+    velocity: f32,
+    last_tick: Option<iced::time::Instant>,
+}
+
+impl Default for PulseSpring {
+    fn default() -> Self {
+        Self {
+            value: 0.0,
+            velocity: 0.0,
+            last_tick: None,
+        }
+    }
+}
+
+impl PulseSpring {
+    pub fn value(&self) -> f32 {
+        self.value
+    }
+
+    pub fn trigger(&mut self) {
+        self.value = 1.0;
+        self.velocity = 0.0;
+        self.last_tick = None;
+    }
+
+    pub fn is_animating(&self) -> bool {
+        self.value > 0.001 || self.velocity.abs() > 0.001
+    }
+
+    pub fn tick(&mut self, now: iced::time::Instant) {
+        let dt = self
+            .last_tick
+            .map(|last| (now - last).as_secs_f32())
+            .unwrap_or(1.0 / 60.0)
+            .clamp(0.0, 0.05);
+
+        self.last_tick = Some(now);
+
+        let stiffness = 90.0;
+        let damping = 18.0;
+        let acceleration = -stiffness * self.value - damping * self.velocity;
+
+        self.velocity += acceleration * dt;
+        self.value += self.velocity * dt;
+
+        if self.value <= 0.001 && self.velocity.abs() <= 0.01 {
+            self.value = 0.0;
+            self.velocity = 0.0;
+            self.last_tick = None;
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum WindowKind {
     Settings,
@@ -26,7 +82,7 @@ pub struct WindowState {
 pub struct EntityWindowState {
     pub entity_id: String,
     pub last: Option<EntityState>,
-    pub pulse: f32, // TODO: Replace with Animation/spring. Currently just easy "animation paramter" (0..1), později nahradit Animation/spring
+    pub pulse: PulseSpring, // TODO: Replace with Animation/spring. Currently just easy "animation paramter" (0..1), později nahradit Animation/spring
     pub hovered: bool,
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -41,14 +41,27 @@ pub fn humanize_magnitude(raw: &str) -> String {
         (n / 1_000_000.0, "M")
     } else if abs >= 1_000.0 {
         (n / 1_000.0, "k")
+    } else if abs > 0.0 && abs < 1e-9 {
+        (n * 1e12, "p")
+    } else if abs > 0.0 && abs < 1e-6 {
+        (n * 1e9, "n")
     } else if abs > 0.0 && abs < 0.001 {
         (n * 1_000_000.0, "µ")
-    } else if abs > 0.0 && abs < 1.0 {
+    } else if abs > 0.0 && abs < 0.01 {
         (n * 1_000.0, "m")
     } else {
         // 1..1000 range — no compression needed
         return raw.to_string();
     };
 
-    format!("{:.2} {}{}", scaled, prefix, unit)
+    let formated = format!("{:.2}", scaled);
+    let trimmed = formated.trim_end_matches('0').trim_end_matches('.');
+
+    let display = if trimmed.is_empty() || trimmed == "-" {
+        formated.as_str()
+    } else {
+        trimmed
+    };
+
+    format!("{} {}{}", display, prefix, unit)
 }

--- a/src/ui/components/card.rs
+++ b/src/ui/components/card.rs
@@ -78,43 +78,68 @@ pub fn card_with_border(
     border_color: iced::Color,
 ) -> Element<Message> {
     let border_width = if border_color.a <= 0.1 { 0.0 } else { 1.0 };
+    #[cfg(target_os = "windows")]
+    {
+        // Windows: DWM rounds the outer window; inner radius
+        // would create double-round artifact. Border line is
+        // still drawn (animated alpha) and gets pixel-clipped
+        // by DWM at the corners — so visually we still get
+        // rounded edges on the border highlight, just from
+        // the OS rather than from our shader.
 
+        let base: Element<Message> = container(content)
+            .padding(metric::PAD)
+            .style(move |_theme| container::Style {
+                background: Some(Background::Color(p.card)),
+                border: Border {
+                    radius: 0.0.into(),
+                    width: 0.0,
+                    color: p.border,
+                },
+                shadow: iced::Shadow::default(),
+                ..Default::default()
+            })
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into();
+
+        let ring: Element<Message> = container(
+            container(iced::widget::space())
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .style(move |_theme| container::Style {
+                    background: None,
+                    border: Border {
+                        radius: 8.0.into(),
+                        width: border_width,
+                        color: border_color,
+                    },
+                    shadow: iced::Shadow::default(),
+                    snap: true,
+                    ..Default::default()
+                }),
+        )
+        .padding(1.0)
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into();
+
+        return stack![base, ring]
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into();
+    }
+    #[cfg(not(target_os = "windows"))]
     container(content)
         .padding(metric::PAD)
         .style(move |_theme| container::Style {
             background: Some(Background::Color(p.card)),
             border: Border {
-                radius: {
-                    // Windows: DWM rounds the outer window; inner radius
-                    // would create double-round artifact. Border line is
-                    // still drawn (animated alpha) and gets pixel-clipped
-                    // by DWM at the corners — so visually we still get
-                    // rounded edges on the border highlight, just from
-                    // the OS rather than from our shader.
-                    #[cfg(target_os = "windows")]
-                    {
-                        iced::border::Radius::from(0.0)
-                    }
-
-                    #[cfg(not(target_os = "windows"))]
-                    {
-                        metric::RADIUS.into()
-                    }
-                },
+                radius: { metric::RADIUS.into() },
                 width: border_width,
                 color: border_color,
             },
-            shadow: {
-                #[cfg(target_os = "windows")]
-                {
-                    iced::Shadow::default()
-                }
-
-                #[cfg(not(target_os = "windows"))]
-                {
-                    p.shadow
-                }
-            },
+            shadow: { p.shadow },
             ..Default::default()
         })
         .width(Length::Fill)

--- a/src/ui/entity_window.rs
+++ b/src/ui/entity_window.rs
@@ -119,7 +119,7 @@ pub fn view(
     let disconnected_text =
         components::error_message("You are disconected from Home Assistant!", p);
 
-    let ring = pulse_border(p, state.pulse);
+    let ring = pulse_border(p, state.pulse.value());
 
     let inner = column![
         title_text,

--- a/src/widget_size/tests.rs
+++ b/src/widget_size/tests.rs
@@ -3,7 +3,7 @@ use crate::helpers::humanize_magnitude;
 #[test]
 fn compresses_large_watts() {
     assert_eq!(humanize_magnitude("1234567 W"), "1.23 MW");
-    assert_eq!(humanize_magnitude("5000 W"), "5.00 kW");
+    assert_eq!(humanize_magnitude("5000 W"), "5 kW");
 }
 
 #[test]
@@ -31,5 +31,38 @@ fn handles_non_numeric() {
 
 #[test]
 fn compresses_small() {
-    assert_eq!(humanize_magnitude("0.0005 A"), "500.00 µA");
+    assert_eq!(humanize_magnitude("0.0005 A"), "500 µA");
+}
+#[test]
+fn does_not_scale_moderately_small_values() {
+    assert_eq!(humanize_magnitude("0.1 A"), "0.1 A");
+    assert_eq!(humanize_magnitude("0.5 A"), "0.5 A");
+    assert_eq!(humanize_magnitude("0.05 A"), "0.05 A");
+}
+
+#[test]
+fn scales_truly_small_values() {
+    assert_eq!(humanize_magnitude("0.005 A"), "5 mA");
+    assert_eq!(humanize_magnitude("0.0001 A"), "100 µA");
+    assert_eq!(humanize_magnitude("0.0051 A"), "5.1 mA");
+}
+
+#[test]
+fn trims_trailing_zeros() {
+    assert_eq!(humanize_magnitude("5000 W"), "5 kW");
+    assert_eq!(humanize_magnitude("1500 W"), "1.5 kW");
+    assert_eq!(humanize_magnitude("1230000 W"), "1.23 MW");
+}
+
+#[test]
+fn scales_into_nano_and_pico() {
+    assert_eq!(humanize_magnitude("0.000000001 A"), "1 nA"); // 1e-9
+    assert_eq!(humanize_magnitude("0.0000000005 A"), "500 pA"); // 5e-10
+    assert_eq!(humanize_magnitude("0.000000000001 A"), "1 pA"); // 1e-12
+}
+
+#[test]
+fn boundary_between_milli_and_micro() {
+    assert_eq!(humanize_magnitude("0.001 A"), "1 mA");
+    assert_eq!(humanize_magnitude("0.0001 A"), "100 µA"); // dropped from milli to micro
 }


### PR DESCRIPTION
## v0.0.7

Small follow-up to 0.0.6 — fixes for the smart-number formatter and
nicer pulse animation in entity widgets. 

### Fixes

- **Smart-number formatter no longer pads short values** (#62) —
  `0.1 A` previously rendered as `100.00 mA` (longer than the
  source); now passes through unchanged. Trailing zeros are also
  trimmed so `5.00 kW` reads as `5 kW`. Existing widgets with
  Smart number formatting enabled will look cleaner immediately
  after upgrading.

### Refinements

- **Pulse animation now uses spring physics** — the ring around
  entity widgets that flashes when a sensor value updates eases
  in and out smoothly instead of stepping. Looks the same; feels
  better.

### Pull requests in this release

- #62 Tighten milli threshold + trim trailing zeros in
  humanize_magnitude
- #63  Spring-physics pulse animation