### PR TITLE
Feat/sysinfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,6 +2114,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-quartz-core 0.3.2",
  "rustc-hash 2.1.2",
+ "sysinfo 0.33.1",
  "thiserror 2.0.18",
  "tracing",
  "wasm-bindgen-futures",
@@ -2376,12 +2396,10 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2752,6 +2770,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,6 +3140,16 @@ dependencies = [
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -3845,6 +3882,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "read-fonts"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4565,6 +4622,7 @@ dependencies = [
  "directories",
  "flate2",
  "iced",
+ "iced_winit",
  "keyring",
  "open",
  "rand 0.10.1",
@@ -4573,6 +4631,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "sysinfo 0.38.4",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -4742,6 +4801,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -5423,9 +5510,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5436,19 +5523,23 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5456,9 +5547,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5469,9 +5560,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
@@ -5661,9 +5752,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5904,6 +5995,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -5931,6 +6032,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5972,6 +6085,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
@@ -5986,6 +6110,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6039,6 +6174,15 @@ dependencies = [
  "windows-link",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,17 @@ diagnostics = []
 anyhow = "1.0.102"
 auto-launch = "0.6.0"
 chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
-iced = { version = "0.14.0", features = ["wgpu", "tokio", "markdown"] }
+iced = { version = "0.14.0", features = [
+    "wgpu",
+    "tokio",
+    "markdown",
+    "sysinfo",
+] }
+iced_winit = { version = "0.14.0", features = ["sysinfo"] }
 directories = "6.0.0"
 thiserror = "2.0.18"
 
+sysinfo = "0.38.4"
 reqwest = { version = "0.13.2", default-features = false, features = [
     "json",
     "rustls",

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -1,6 +1,7 @@
 use crate::ha::types::HaError;
 use crate::ha::{EntityState, HaConnectionConfig, HaEvent};
 use crate::logger::LogType;
+use crate::system_info::{SysinfoData, SystemInfo};
 use crate::ui::platform::window_settings;
 use crate::ui::settings::*;
 use crate::update;
@@ -9,6 +10,7 @@ use crate::{ha, logger};
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
+use iced::system::Information;
 use iced::window;
 use iced::{Element, Task};
 
@@ -61,6 +63,10 @@ pub struct Snapdash {
 
     pub config_save_in_flight: bool,
     pub config_save_pending: bool,
+
+    pub sys_data: Option<SysinfoData>,
+    pub sys_info: Option<SystemInfo>,
+    pub iced_sys_info: Option<iced::system::Information>,
 }
 
 #[derive(Debug, Clone)]
@@ -138,6 +144,12 @@ pub enum Message {
     AdaptiveFontChanged(bool),
     AdaptiveValueChanged(bool),
     ShowMeasurementInfoChanged(bool),
+
+    SysInfoFetched(Information),
+    SysExtrasFetched(SysinfoData),
+    RefresSystemInfo,
+    CopySystemInfo,
+    CopySystemInfoMd,
 }
 
 impl Default for Snapdash {
@@ -168,8 +180,19 @@ impl Snapdash {
             last_widget_move_at: None,
             config_save_in_flight: false,
             config_save_pending: false,
+            sys_info: None,
+            iced_sys_info: None,
+            sys_data: None,
         }
     }
+
+    fn try_combine_sysinfo(&mut self) {
+        if let (Some(iced), Some(extras)) = (&self.iced_sys_info, &self.sys_data) {
+            self.sys_info = Some(SystemInfo::from_parts(iced, extras));
+            tracing::info!("system info ready");
+        }
+    }
+
     fn rebuild_active_settings_sensors(&mut self) {
         self.active_settings_sensors = self
             .settings_sensors
@@ -393,6 +416,54 @@ impl Snapdash {
         match message {
             Message::Noop => Task::none(),
 
+            Message::CopySystemInfo => {
+                if let Some(snapshoot) = &self.sys_info {
+                    let text = snapshoot.to_clipboard_string();
+                    self.set_status("System info copied", LogType::DoNotLog);
+                    return iced::clipboard::write(text);
+                }
+                Task::none()
+            }
+
+            Message::CopySystemInfoMd => {
+                if let Some(snapshoot) = &self.sys_info {
+                    let text = snapshoot.to_md_string();
+                    self.set_status("System info copied as Markdown", LogType::DoNotLog);
+                    return iced::clipboard::write(text);
+                }
+                Task::none()
+            }
+
+            Message::SysInfoFetched(i) => {
+                self.iced_sys_info = Some(i);
+                self.try_combine_sysinfo();
+                Task::none()
+            }
+
+            Message::SysExtrasFetched(data) => {
+                self.sys_data = Some(data);
+                self.try_combine_sysinfo();
+                Task::none()
+            }
+
+            Message::RefresSystemInfo => {
+                self.sys_info = None;
+                self.iced_sys_info = None;
+                self.sys_data = None;
+                // Same trigger as in OpenSettings — could refactor into helper
+                Task::batch([
+                    iced::system::information().map(Message::SysInfoFetched),
+                    Task::perform(
+                        async {
+                            tokio::task::spawn_blocking(SysinfoData::collect)
+                                .await
+                                .unwrap_or_default()
+                        },
+                        Message::SysExtrasFetched,
+                    ),
+                ])
+            }
+
             Message::AutostartChanged(want) => {
                 let previous = self.config.autostart;
                 self.config.autostart = want;
@@ -602,7 +673,13 @@ impl Snapdash {
 
             Message::SettingsPageSelected(page) => {
                 self.settings_page = page;
-                Task::none()
+
+                // Refresh sysinfo page on selection
+                if matches!(page, SettingsPage::Sysinfo) {
+                    iced::system::information().map(Message::SysInfoFetched)
+                } else {
+                    Task::none()
+                }
             }
 
             Message::SettingsSearchChanged(value) => {
@@ -653,15 +730,6 @@ impl Snapdash {
                         self.config = cfg;
                         crate::autostart::validate_state(self.config.autostart);
 
-                        tasks.push(Task::perform(
-                            async {
-                                tokio::task::spawn_blocking(token::presence)
-                                    .await
-                                    .unwrap_or_else(|e| TokenPresence::AccessFailed(e.to_string()))
-                            },
-                            Message::HaTokenPresenceChecked,
-                        ));
-
                         self.rebuild_selected_widgets();
                         self.set_status("Config loaded", LogType::Info);
 
@@ -676,10 +744,21 @@ impl Snapdash {
                             tasks.push(open_task);
                         }
 
+                        let key_chain_task = Task::perform(
+                            async {
+                                tokio::task::spawn_blocking(token::presence)
+                                    .await
+                                    .unwrap_or_else(|e| TokenPresence::AccessFailed(e.to_string()))
+                            },
+                            Message::HaTokenPresenceChecked,
+                        );
+
                         return if tasks.is_empty() {
                             Task::none()
                         } else {
-                            Task::batch(tasks)
+                            // Lazily create key-chain task. The task should be the last on boot
+                            // while it is blocking spawn.
+                            Task::batch(tasks).chain(key_chain_task)
                         };
                     }
                     Err(e) => {
@@ -734,6 +813,11 @@ impl Snapdash {
             }
 
             Message::WindowOpened { id, kind } => {
+                // Lazy-fetch system info once we have at least one window -
+                // the compositor (and therefore grapichs_adapter info).
+                // Graphics info is only available after the first windows open.
+                // If we trigger sys_info on the boot() the request races compositor init.
+
                 let mut entity = EntityWindowState::default();
 
                 if let WindowKind::Entity { entity_id } = &kind {
@@ -802,10 +886,27 @@ impl Snapdash {
             Message::OpenSettings => {
                 // if Settings window is opened, give focus
                 //
+
                 if let Some(settings_id) = find_window_id(&self.windows, WindowKind::Settings, None)
                 {
                     return iced::window::gain_focus::<Message>(settings_id);
                 }
+
+                let sysinfo_task = if self.sys_info.is_none() {
+                    let iced_part = iced::system::information().map(Message::SysInfoFetched);
+                    let extras_part = Task::perform(
+                        async {
+                            tokio::task::spawn_blocking(SysinfoData::collect)
+                                .await
+                                .unwrap_or_default()
+                        },
+                        Message::SysExtrasFetched,
+                    );
+
+                    Task::batch([iced_part, extras_part])
+                } else {
+                    Task::none()
+                };
 
                 // The platform helper adds a transparent shadow margin on
                 // Linux (where we render our own shader shadow) and is a
@@ -813,10 +914,12 @@ impl Snapdash {
                 // own shadow). See `ui::platform` module doc.
                 let settings = window_settings(iced::Size::new(920.0, 640.0), true);
                 let (id, task_id) = window::open(settings);
-                task_id.map(move |_| Message::WindowOpened {
-                    id,
-                    kind: WindowKind::Settings,
-                })
+                task_id
+                    .map(move |_| Message::WindowOpened {
+                        id,
+                        kind: WindowKind::Settings,
+                    })
+                    .chain(sysinfo_task)
             }
 
             Message::OpenEntity(entity_id) => {

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -193,6 +193,24 @@ impl Snapdash {
         }
     }
 
+    fn fetch_system_info(&mut self) -> Task<Message> {
+        self.sys_info = None;
+        self.sys_data = None;
+        self.iced_sys_info = None;
+
+        Task::batch([
+            iced::system::information().map(Message::SysInfoFetched),
+            Task::perform(
+                async {
+                    tokio::task::spawn_blocking(SysinfoData::collect)
+                        .await
+                        .unwrap_or_default()
+                },
+                Message::SysExtrasFetched,
+            ),
+        ])
+    }
+
     fn rebuild_active_settings_sensors(&mut self) {
         self.active_settings_sensors = self
             .settings_sensors
@@ -446,23 +464,7 @@ impl Snapdash {
                 Task::none()
             }
 
-            Message::RefresSystemInfo => {
-                self.sys_info = None;
-                self.iced_sys_info = None;
-                self.sys_data = None;
-                // Same trigger as in OpenSettings — could refactor into helper
-                Task::batch([
-                    iced::system::information().map(Message::SysInfoFetched),
-                    Task::perform(
-                        async {
-                            tokio::task::spawn_blocking(SysinfoData::collect)
-                                .await
-                                .unwrap_or_default()
-                        },
-                        Message::SysExtrasFetched,
-                    ),
-                ])
-            }
+            Message::RefresSystemInfo => self.fetch_system_info(),
 
             Message::AutostartChanged(want) => {
                 let previous = self.config.autostart;
@@ -676,7 +678,7 @@ impl Snapdash {
 
                 // Refresh sysinfo page on selection
                 if matches!(page, SettingsPage::Sysinfo) {
-                    iced::system::information().map(Message::SysInfoFetched)
+                    self.fetch_system_info()
                 } else {
                     Task::none()
                 }
@@ -893,17 +895,7 @@ impl Snapdash {
                 }
 
                 let sysinfo_task = if self.sys_info.is_none() {
-                    let iced_part = iced::system::information().map(Message::SysInfoFetched);
-                    let extras_part = Task::perform(
-                        async {
-                            tokio::task::spawn_blocking(SysinfoData::collect)
-                                .await
-                                .unwrap_or_default()
-                        },
-                        Message::SysExtrasFetched,
-                    );
-
-                    Task::batch([iced_part, extras_part])
+                    self.fetch_system_info()
                 } else {
                     Task::none()
                 };

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,4 +1,6 @@
 //! Simple human-readable size
+
+use std::time::Duration;
 pub fn humanize_bytes(n: u64) -> String {
     const KB: u64 = 1024;
     const MB: u64 = KB * 1024;
@@ -64,4 +66,18 @@ pub fn humanize_magnitude(raw: &str) -> String {
     };
 
     format!("{} {}{}", display, prefix, unit)
+}
+
+pub fn humanize_duration(d: Duration) -> String {
+    let total = d.as_secs();
+    let days = total / 86400;
+    let hours = (total % 86400) / 3600;
+    let minutes = (total % 3600) / 60;
+    if days > 0 {
+        format!("{days}d {hours}h {minutes}m")
+    } else if hours > 0 {
+        format!("{hours}h {minutes}m")
+    } else {
+        format!("{minutes}m")
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod ha;
 pub mod helpers;
 pub mod logger;
+pub mod system_info;
 pub mod theme;
 pub mod ui;
 pub mod update;

--- a/src/system_info.rs
+++ b/src/system_info.rs
@@ -1,0 +1,172 @@
+//! Combines system info: sysinfo 0.38 with iced GPU iced
+//! sysinfo doesn't query GPU
+
+use std::time::Duration;
+
+use crate::helpers::humanize_duration;
+
+#[derive(Debug, Clone)]
+pub struct SystemInfo {
+    //GPU - from iced::system::Information
+    pub graphics_adapter: String,
+    pub graphics_backend: String,
+
+    //Everything else from sysinfo 0.38
+    pub host_name: Option<String>,
+    pub system_name: Option<String>,
+    pub system_version: Option<String>,
+    pub kernel_version: Option<String>,
+
+    pub cpu_brand: String,
+    pub cpu_cores_physical: Option<usize>,
+    pub cpu_cores_logical: usize,
+    pub cpu_usage: f32,
+
+    pub memory_total: u64,
+    pub memory_used: u64,
+    pub memory_available: u64,
+
+    pub uptime: Duration,
+    pub boot_time_unix: u64,
+}
+
+/// Synchronous sysinfo collection - via `tokio::task::spawn_blocking`
+#[derive(Debug, Clone, Default)]
+pub struct SysinfoData {
+    pub host_name: Option<String>,
+    pub system_name: Option<String>,
+    pub system_version: Option<String>,
+    pub kernel_version: Option<String>,
+    pub cpu_brand: String,
+    pub cpu_cores_physical: Option<usize>,
+    pub cpu_cores_logical: usize,
+    pub cpu_usage: f32,
+    pub memory_total: u64,
+    pub memory_used: u64,
+    pub memory_available: u64,
+    pub uptime: Duration,
+    pub boot_time_unix: u64,
+}
+
+impl SysinfoData {
+    pub fn collect() -> Self {
+        use sysinfo::System;
+
+        let mut system = System::new_all();
+
+        // Two refreshes for accurate CPU% — first establishes baseline,
+        // second computes the delta. Single refresh returns 0% always.
+        system.refresh_all();
+
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        system.refresh_cpu_all();
+
+        let cpu_brand = system
+            .cpus()
+            .first()
+            .map(|c| c.brand().to_string())
+            .unwrap_or_default();
+
+        let cpu_usage = system.global_cpu_usage();
+
+        Self {
+            host_name: System::host_name(),
+            system_name: System::name(),
+            system_version: System::os_version(),
+            kernel_version: System::kernel_version(),
+            cpu_brand,
+            cpu_cores_physical: System::physical_core_count(),
+            cpu_cores_logical: system.cpus().len(),
+            cpu_usage,
+            memory_total: system.total_memory(),
+            memory_used: system.used_memory(),
+            memory_available: system.available_memory(),
+            uptime: Duration::from_secs(System::uptime()),
+            boot_time_unix: System::boot_time(),
+        }
+    }
+}
+
+impl SystemInfo {
+    // Combines the two parallel fetches into a single structure
+    pub fn from_parts(iced: &iced::system::Information, extras: &SysinfoData) -> Self {
+        Self {
+            graphics_adapter: iced.graphics_adapter.clone(),
+            graphics_backend: iced.graphics_backend.clone(),
+
+            host_name: extras.host_name.clone(),
+            system_name: extras.system_name.clone(),
+            system_version: extras.system_version.clone(),
+            kernel_version: extras.kernel_version.clone(),
+
+            cpu_brand: extras.cpu_brand.clone(),
+            cpu_cores_physical: extras.cpu_cores_physical,
+            cpu_cores_logical: extras.cpu_cores_logical,
+            cpu_usage: extras.cpu_usage,
+
+            memory_available: extras.memory_available,
+            memory_used: extras.memory_used,
+            memory_total: extras.memory_total,
+
+            uptime: extras.uptime,
+            boot_time_unix: extras.boot_time_unix,
+        }
+    }
+
+    pub fn to_clipboard_string(&self) -> String {
+        format!(
+            "Snapdash {snap_version}
+Hostname: {host}
+OS: {os} {ver}
+Kernel: {kernel}
+CPU: {cpu} ({cores_phys}/{cores_log} cores, {load:.1}% load)
+Memory: {mem_used:.1} / {mem_total:.1} GB ({mem_avail:.1} GB available)
+GPU: {gpu} ({backend})
+Uptime: {uptime}",
+            snap_version = env!("CARGO_PKG_VERSION"),
+            host = self.host_name.as_deref().unwrap_or("?"),
+            os = self.system_name.as_deref().unwrap_or("?"),
+            ver = self.system_version.as_deref().unwrap_or(""),
+            kernel = self.kernel_version.as_deref().unwrap_or("?"),
+            cpu = self.cpu_brand,
+            cores_phys = self.cpu_cores_physical.unwrap_or(0),
+            cores_log = self.cpu_cores_logical,
+            load = self.cpu_usage,
+            mem_used = self.memory_used as f64 / 1_073_741_824.0,
+            mem_total = self.memory_total as f64 / 1_073_741_824.0,
+            mem_avail = self.memory_available as f64 / 1_073_741_824.0,
+            gpu = self.graphics_adapter,
+            backend = self.graphics_backend,
+            uptime = humanize_duration(self.uptime),
+        )
+    }
+
+    pub fn to_md_string(&self) -> String {
+        format!(
+            "|Field | Value |
+| ----- | ----- |
+| Snapdash | `{snap_version}` |
+| Hostname |  `{host}` |
+| OS | `{os} {ver}` |
+| Kernel | `{kernel}` |
+| CPU | `{cpu}` ({cores_phys}/{cores_log} cores, {load:.1}% load) |
+| Memory | {mem_used:.1} / {mem_total:.1} GB |
+| GPU | `{gpu}` ({backend}) |
+| Uptime | {uptime} |",
+            snap_version = env!("CARGO_PKG_VERSION"),
+            host = self.host_name.as_deref().unwrap_or("?"),
+            os = self.system_name.as_deref().unwrap_or("?"),
+            ver = self.system_version.as_deref().unwrap_or(""),
+            kernel = self.kernel_version.as_deref().unwrap_or("?"),
+            cpu = self.cpu_brand,
+            cores_phys = self.cpu_cores_physical.unwrap_or(0),
+            cores_log = self.cpu_cores_logical,
+            load = self.cpu_usage,
+            mem_used = self.memory_used as f64 / 1_073_741_824.0,
+            mem_total = self.memory_total as f64 / 1_073_741_824.0,
+            gpu = self.graphics_adapter,
+            backend = self.graphics_backend,
+            uptime = humanize_duration(self.uptime),
+        )
+    }
+}

--- a/src/ui/components/scrollable.rs
+++ b/src/ui/components/scrollable.rs
@@ -1,5 +1,5 @@
 use iced::Element;
-use iced::widget::scrollable::{AutoScroll, Rail, Scroller, Status, Style};
+use iced::widget::scrollable::{AutoScroll, Direction, Rail, Scrollbar, Scroller, Status, Style};
 
 use crate::app::Message;
 use crate::theme::Palette;
@@ -8,50 +8,60 @@ pub fn scrollable<'a>(
     content: Element<'a, Message>,
     p: Palette,
 ) -> iced::widget::Scrollable<'a, Message> {
-    iced::widget::scrollable(content).style(move |_theme, status| {
-        let is_interacting = matches!(
-            status,
-            Status::Hovered {
-                is_horizontal_scrollbar_hovered: true,
-                ..
-            } | Status::Hovered {
-                is_vertical_scrollbar_hovered: true,
-                ..
-            } | Status::Dragged { .. }
-        );
+    // Configure the vertical scrollbar with a gap so it sits in its
+    // own gutter instead of overlaying the content text on the right.
+    let scrollbar = Scrollbar::default()
+        .width(8.0)
+        .margin(2.0)
+        .scroller_width(6.0)
+        .spacing(8.0);
 
-        let scroller_color = if is_interacting {
-            p.accent_dim
-        } else {
-            p.border_hovered
-        };
+    iced::widget::scrollable(content)
+        .direction(Direction::Vertical(scrollbar))
+        .style(move |_theme, status| {
+            let is_interacting = matches!(
+                status,
+                Status::Hovered {
+                    is_horizontal_scrollbar_hovered: true,
+                    ..
+                } | Status::Hovered {
+                    is_vertical_scrollbar_hovered: true,
+                    ..
+                } | Status::Dragged { .. }
+            );
 
-        let rail = Rail {
-            background: Some(iced::Background::Color(p.accent_tint)),
-            border: iced::Border {
-                radius: 4.0.into(),
-                ..Default::default()
-            },
-            scroller: Scroller {
-                background: iced::Background::Color(scroller_color),
+            let scroller_color = if is_interacting {
+                p.accent_dim
+            } else {
+                p.border_hovered
+            };
+
+            let rail = Rail {
+                background: Some(iced::Background::Color(p.accent_tint)),
                 border: iced::Border {
                     radius: 4.0.into(),
                     ..Default::default()
                 },
-            },
-        };
+                scroller: Scroller {
+                    background: iced::Background::Color(scroller_color),
+                    border: iced::Border {
+                        radius: 4.0.into(),
+                        ..Default::default()
+                    },
+                },
+            };
 
-        Style {
-            container: iced::widget::container::Style::default(),
-            vertical_rail: rail,
-            horizontal_rail: rail,
-            gap: None,
-            auto_scroll: AutoScroll {
-                background: iced::Background::Color(p.accent_tint),
-                border: iced::Border::default(),
-                icon: p.text_body,
-                shadow: iced::Shadow::default(),
-            },
-        }
-    })
+            Style {
+                container: iced::widget::container::Style::default(),
+                vertical_rail: rail,
+                horizontal_rail: rail,
+                gap: None,
+                auto_scroll: AutoScroll {
+                    background: iced::Background::Color(p.accent_tint),
+                    border: iced::Border::default(),
+                    icon: p.text_body,
+                    shadow: iced::Shadow::default(),
+                },
+            }
+        })
 }

--- a/src/ui/components/settings_components.rs
+++ b/src/ui/components/settings_components.rs
@@ -1,6 +1,6 @@
 use crate::theme::{Palette, metric, text_size};
-use crate::ui::components;
 use crate::ui::components::button::ButtonType;
+use crate::ui::components::{self};
 use iced::Length;
 use iced::widget::{column, row};
 use iced::{Element, widget::text::IntoFragment};
@@ -31,6 +31,7 @@ where
 pub fn page_with_sections<'a, I>(
     title: impl IntoFragment<'a>,
     items: I,
+    scrollable: bool,
     p: Palette,
 ) -> Element<'a, Message>
 where
@@ -40,13 +41,68 @@ where
         .spacing(metric::GAP)
         .width(Length::Fill);
 
-    items
+    let items = items
         .into_iter()
         .fold(outer, |col, item| col.push(item))
-        .into()
+        .into();
+
+    if scrollable {
+        components::scrollable(items, p).into()
+    } else {
+        items
+    }
 }
 
-/// One row i a settings card: left side a label and optional
+/// Make settings page with scrollable content and non-scrollable bottom.
+///
+/// Scrollable items will be on the top of page
+/// Non scrollabele (fixed) items will be at the bottom page.
+///
+/// You should consider make non scrollable only buttons row or just
+/// few items of any of item_with_*
+pub fn page_with_scrollable_sections<'a, S, F>(
+    title: impl IntoFragment<'a>,
+    scrollable_items: S,
+    fixed_items: F,
+    p: Palette,
+) -> Element<'a, Message>
+where
+    S: IntoIterator<Item = Element<'a, Message>>,
+    F: IntoIterator<Item = Element<'a, Message>>,
+{
+    // prepare scrollable items as Element
+    let scrollable_col = column![]
+        .spacing(metric::GAP)
+        .width(Length::Fill)
+        .height(Length::Fill);
+    let mut scrollable_items: Element<'a, Message> = scrollable_items
+        .into_iter()
+        .fold(scrollable_col, |col, item| col.push(item))
+        .into();
+    scrollable_items = components::scrollable(scrollable_items, p)
+        .height(Length::Fill)
+        .into();
+
+    // prepare non scrolable items as Element
+    let non_scrollable_col = column![].width(Length::Fill).spacing(metric::GAP);
+    let non_scrollable_items: Element<'a, Message> = fixed_items
+        .into_iter()
+        .fold(non_scrollable_col, |col, item| col.push(item))
+        .into();
+
+    // page generation
+    column![
+        components::title(title, p),
+        scrollable_items,
+        non_scrollable_items,
+    ]
+    .width(Length::Fill)
+    .height(Length::Fill)
+    .spacing(metric::GAP)
+    .into()
+}
+
+/// One row in a settings card: left side a label and optional
 /// helper text, right side carry action widget.
 fn item<'a>(
     label: impl IntoFragment<'a>,

--- a/src/ui/settings/mod.rs
+++ b/src/ui/settings/mod.rs
@@ -15,6 +15,7 @@ pub enum SettingsPage {
     Sensors,
     Updates,
     Advanced,
+    Sysinfo,
 }
 
 impl SettingsPage {
@@ -25,6 +26,7 @@ impl SettingsPage {
         Self::Sensors,
         Self::Updates,
         Self::Advanced,
+        Self::Sysinfo,
     ];
 
     pub fn label(self) -> &'static str {
@@ -35,6 +37,7 @@ impl SettingsPage {
             Self::Sensors => "Sensors",
             Self::Updates => "Updates",
             Self::Advanced => "Advanced",
+            Self::Sysinfo => "System information",
         }
     }
 }
@@ -53,6 +56,7 @@ pub fn view(snap: &Snapdash, id: iced::window::Id) -> Element<'_, Message> {
         SettingsPage::Sensors => pages::sensors::view(snap),
         SettingsPage::Updates => pages::updates::view(snap),
         SettingsPage::Advanced => pages::advanced::view(snap),
+        SettingsPage::Sysinfo => pages::sysinfo::view(snap, p),
     };
 
     let body: Element<Message> = iced::widget::row![

--- a/src/ui/settings/pages/advanced.rs
+++ b/src/ui/settings/pages/advanced.rs
@@ -65,6 +65,7 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
                 p,
             ),
         ],
+        false,
         p,
     )
 }

--- a/src/ui/settings/pages/appearance.rs
+++ b/src/ui/settings/pages/appearance.rs
@@ -58,6 +58,7 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
                 p,
             ),
         ],
+        false,
         p,
     )
 }

--- a/src/ui/settings/pages/mod.rs
+++ b/src/ui/settings/pages/mod.rs
@@ -3,4 +3,5 @@ pub mod appearance;
 pub mod connection;
 pub mod general;
 pub mod sensors;
+pub mod sysinfo;
 pub mod updates;

--- a/src/ui/settings/pages/sysinfo.rs
+++ b/src/ui/settings/pages/sysinfo.rs
@@ -1,8 +1,128 @@
 use crate::app::Message;
-use iced::system;
+use crate::helpers::humanize_bytes;
+use crate::ui::components;
+
+use iced::Element;
+
+use iced::widget::row;
 
 use crate::app::Snapdash;
+use crate::theme::Palette;
+use crate::ui::components::error_message;
+use crate::ui::components::settings_components;
 
-pub fn view<'a>(snap: &Snapdash) -> Element<'a, Message> {
-    let s = system::information()
+pub fn view<'a>(snap: &'a Snapdash, p: Palette) -> Element<'a, Message> {
+    if let Some(info) = &snap.sys_info {
+        settings_components::page_with_scrollable_sections(
+            "System information",
+            [
+                settings_components::section(
+                    [settings_components::item_with_status(
+                        "Hostname",
+                        None,
+                        info.host_name.clone().unwrap_or("?".into()),
+                        p,
+                    )],
+                    p,
+                ),
+                settings_components::section(
+                    [
+                        settings_components::item_with_status(
+                            "Operating system",
+                            None,
+                            info.system_name.as_deref().unwrap_or("Unknown"),
+                            p,
+                        ),
+                        settings_components::item_with_status(
+                            "Version",
+                            None,
+                            info.system_version.as_deref().unwrap_or("Unknown"),
+                            p,
+                        ),
+                        settings_components::item_with_status(
+                            "Kernel",
+                            None,
+                            info.kernel_version.as_deref().unwrap_or("Unknown"),
+                            p,
+                        ),
+                    ],
+                    p,
+                ),
+                // CPU section
+                settings_components::section(
+                    [
+                        settings_components::item_with_status(
+                            "CPU Brand",
+                            None,
+                            info.cpu_brand.as_str(),
+                            p,
+                        ),
+                        settings_components::item_with_status(
+                            "Cores",
+                            Some("Physical / Logical / load %"),
+                            format!(
+                                "{} / {} / {:.1}%",
+                                info.cpu_cores_physical.unwrap_or(0),
+                                info.cpu_cores_logical,
+                                info.cpu_usage
+                            ),
+                            p,
+                        ),
+                    ],
+                    p,
+                ),
+                // Memory section
+                settings_components::section(
+                    [
+                        settings_components::item_with_status(
+                            "Memory total",
+                            None,
+                            humanize_bytes(info.memory_total),
+                            p,
+                        ),
+                        settings_components::item_with_status(
+                            "Memory available",
+                            None,
+                            humanize_bytes(info.memory_available),
+                            p,
+                        ),
+                        settings_components::item_with_status(
+                            "Memory used",
+                            None,
+                            humanize_bytes(info.memory_used),
+                            p,
+                        ),
+                    ],
+                    p,
+                ),
+                //Graphics adapter
+                settings_components::section(
+                    [
+                        settings_components::item_with_status(
+                            "Graphics adapter",
+                            None,
+                            info.graphics_adapter.as_str(),
+                            p,
+                        ),
+                        settings_components::item_with_status(
+                            "Graphics backend",
+                            None,
+                            info.graphics_backend.as_str(),
+                            p,
+                        ),
+                    ],
+                    p,
+                ),
+            ],
+            [row![
+                components::primary_button("Copy as Markdown", p, Some(Message::CopySystemInfoMd)),
+                components::pill_button("Copy as simple text", p, Some(Message::CopySystemInfo)),
+                components::pill_button("Refresh", p, Some(Message::RefresSystemInfo)),
+            ]
+            .into()],
+            p,
+        )
+    } else {
+        error_message("OS info is loading ...", p)
+    }
 }

--- a/src/ui/settings/pages/sysinfo.rs
+++ b/src/ui/settings/pages/sysinfo.rs
@@ -1,0 +1,8 @@
+use crate::app::Message;
+use iced::system;
+
+use crate::app::Snapdash;
+
+pub fn view<'a>(snap: &Snapdash) -> Element<'a, Message> {
+    let s = system::information()
+}


### PR DESCRIPTION
feat(settings): System Information page with hybrid sysinfo

Adds a System Information settings page that combines GPU data from
iced (wgpu adapter introspection — graphics_adapter + backend) with
everything else from the sysinfo 0.38 crate directly (hostname,
OS/kernel version, CPU brand + physical/logical cores + live load,
total/used/available memory, uptime). The two sources are fetched in
parallel and merged in a single SystemSnapshot once both arrive.

Fetch is lazy on first Settings open — iced::system::information()
needs the compositor, which only exists after a window is created, so
triggering from boot() races init and the channel never fulfills.

Adds a clipboard copy action (iced::clipboard::write) that exports the
snapshot as plain text for issue reports, plus a manual refresh.

Supporting changes:
- settings_components::page_with_scrollable_sections — scrollable
  section list with a pinned fixed-items footer. Uses two independent
  generic params so scrollable and fixed arrays can differ in length.
- components::scrollable now configures a vertical scrollbar gutter
  (spacing) so the rail no longer overlays content text. Fixes the
  same overlap on the Sensors page.
- helpers: humanize_duration for the uptime row.

sysinfo 0.38 ships alongside the 0.33 bundled by iced (~1MB binary
overhead) — accepted in exchange for the richer API (live CPU load,
available memory, physical core count) that the iced bundle lacks.