### PR TITLE
feat: custom JSON themes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,9 @@ keyring = { version = "3.6.3", features = [
     "crypto-rust",
 ] }
 
+[dev-dependencies]
+tempfile = "3.27.0"
+
 [patch.crates-io]
 iced = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p10" }
 iced_winit = { git = "https://github.com/schizza/iced.git", tag = "snapdash-v0.14.0-p10" }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ SnapDash is designed to run quietly in the background without leaks, lag, or sur
 - **Real-time** updates via Home Assistant WebSocket API
 - **Frameless widgets** - pin individual sensors as floating macOS-style cards
 - **Native look** - Mac Light / Mac Dark themes, smooth pulse animations on state change
+- **Custom themes** - drop a JSON file in your themes folder to fully recolor the UI; share or download themes like Dracula, Nord, Catppuccin
 - **Secure token storage** - credentials lives in OS keychain (macOD Keychain / Windows Credential Manager / Linux Secret Service), never in plain text
 - **Cross-platform** - macOS, Windows, Linux
 - **Lightweight** - low CPU / memory footprint, designed to run 24/7 in background
@@ -140,6 +141,90 @@ If the config is corrupted, Snapdash falls back to defaults and writes a fresh f
 | **Windows** | `%APPDATA%\dev.snapdash.Snapdash\config.json` | `%APPDATA%\dev.snapdash.Snapdash\debug.log` |
 | **Linux** | `~/.config/snapdash/config.json` | `~/.local/share/snapdash/debug.log` |
 
+## Custom themes
+
+Beyond the built-in **Mac Light** and **Mac Dark**, Snapdash loads any
+JSON theme you drop into its `themes/` folder. Write your own, or grab
+a ready-made one (Dracula, Nord, Catppuccin, …) and place the file in:
+
+| OS | Themes folder |
+| --- | --- |
+| **macOS** | `~/Library/Application Support/dev.snapdash.Snapdash/themes/` |
+| **Windows** | `%APPDATA%\dev.snapdash.Snapdash\themes\` |
+| **Linux** | `~/.config/snapdash/themes/` |
+
+The folder is scanned at startup; every valid `*.json` shows up in
+**Settings → Appearance → Theme**. A malformed theme is skipped (with a
+warning in the log) — it never blocks the others or crashes the picker.
+
+### Theme file structure
+
+A theme is a single self-contained JSON file. Colors are hex strings,
+either `#rrggbb` (opaque) or `#rrggbbaa` (with alpha):
+
+```json
+{
+  "schema": 1,
+  "name": "Dracula",
+  "author": "Zeno Rocha (port)",
+  "appearance": "dark",
+  "palette": {
+    "bg": "#1e1f29",
+    "card": "#282a36",
+    "card_2": "#21222c",
+    "text_primary": "#f8f8f2",
+    "text_secondary": "#e2e2dc",
+    "text_body": "#f8f8f2",
+    "text_dim": "#6272a4",
+    "text_disabled": "#44475a",
+    "border": "#44475a80",
+    "border_hovered": "#6272a4",
+    "accent": "#bd93f9",
+    "accent_dim": "#a679e0",
+    "accent_tint": "#bd93f926",
+    "shadow": { "color": "#00000059", "offset_x": 0.0, "offset_y": 10.0, "blur_radius": 22.0 },
+    "danger": "#ff5555",
+    "success": "#50fa7b"
+  }
+}
+```
+
+**Top-level fields**
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `schema` | no (default `1`) | Theme format version — for forward compatibility |
+| `name` | **yes** | Display name shown in the theme picker |
+| `author` | no | Credited as "Name — by Author" in the picker |
+| `appearance` | no (default `dark`) | `"light"` or `"dark"` — hint for grouping / OS-mode matching |
+| `palette` | **yes** | The color set (all fields below are required) |
+
+**Palette fields**
+
+| Field | Used for |
+| --- | --- |
+| `bg` | Window / surface background behind cards |
+| `card` | Primary card background |
+| `card_2` | Secondary / nested card background |
+| `text_primary` | Headings |
+| `text_secondary` | Subheadings, labels |
+| `text_body` | Normal body text |
+| `text_dim` | Placeholders, hints, captions |
+| `text_disabled` | Disabled controls |
+| `border` | Default borders |
+| `border_hovered` | Borders on hover |
+| `accent` | Primary accent (selection, active state, links) |
+| `accent_dim` | Dimmed accent variant |
+| `accent_tint` | Very subtle accent fill (use low alpha) |
+| `shadow` | Drop shadow: `{ color, offset_x, offset_y, blur_radius }` |
+| `danger` | Errors, destructive actions |
+| `success` | Connected / OK states |
+
+Ready-made examples live in [`assets/themes/`](assets/themes/) — copy any
+of them into your themes folder as a starting point, then tweak the
+colors. Changing the selected theme in Settings applies instantly; no
+restart needed.
+
 ## Troubleshooting
 
 **Settings window doesn't open**
@@ -162,8 +247,11 @@ On macOS/Windows the token only lives in the keychain. To reset: in Settings, cl
 - [X] Secure token storage in OS keychain
 - [X] Real-time state updates with pulse animations
 - [X] Multi-widget configuration via Settings
-- [X] Local history & 24h sparkline charts
-- [ ] System tray menu & autostart
+- [X] Custom JSON themes (downloadable / user-authored)
+- [X] Cross-platform autostart
+- [X] In-app auto-update
+- [ ] Local history & 24h sparkline charts
+- [ ] System tray menu
 - [ ] Plugin API for non-HA data sources
 - [ ] Linux-specific window hacks (XShape rounded corners)
 - [ ] Code-signed releases (macOS notarization, Windows signing)

--- a/assets/themes/catppuccin-mocha.json
+++ b/assets/themes/catppuccin-mocha.json
@@ -1,0 +1,24 @@
+{
+  "schema": 1,
+  "name": "Catppuccin Mocha",
+  "author": "Catppuccin (port)",
+  "appearance": "dark",
+  "palette": {
+    "bg": "#181825",
+    "card": "#1e1e2e",
+    "card_2": "#11111b",
+    "text_primary": "#cdd6f4",
+    "text_secondary": "#bac2de",
+    "text_body": "#cdd6f4",
+    "text_dim": "#7f849c",
+    "text_disabled": "#6c7086",
+    "border": "#31324480",
+    "border_hovered": "#7f849c",
+    "accent": "#cba6f7",
+    "accent_dim": "#b48fd9",
+    "accent_tint": "#cba6f726",
+    "shadow": { "color": "#0000005c", "offset_x": 0.0, "offset_y": 10.0, "blur_radius": 22.0 },
+    "danger": "#f38ba8",
+    "success": "#a6e3a1"
+  }
+}

--- a/assets/themes/dracula.json
+++ b/assets/themes/dracula.json
@@ -1,0 +1,24 @@
+{
+  "schema": 1,
+  "name": "Dracula",
+  "author": "Zeno Rocha (port)",
+  "appearance": "dark",
+  "palette": {
+    "bg": "#1e1f29",
+    "card": "#282a36",
+    "card_2": "#21222c",
+    "text_primary": "#f8f8f2",
+    "text_secondary": "#e2e2dc",
+    "text_body": "#f8f8f2",
+    "text_dim": "#6272a4",
+    "text_disabled": "#44475a",
+    "border": "#44475a80",
+    "border_hovered": "#6272a4",
+    "accent": "#bd93f9",
+    "accent_dim": "#a679e0",
+    "accent_tint": "#bd93f926",
+    "shadow": { "color": "#00000059", "offset_x": 0.0, "offset_y": 10.0, "blur_radius": 22.0 },
+    "danger": "#ff5555",
+    "success": "#50fa7b"
+  }
+}

--- a/assets/themes/gruvbox-dark.json
+++ b/assets/themes/gruvbox-dark.json
@@ -1,0 +1,24 @@
+{
+  "schema": 1,
+  "name": "Gruvbox Dark",
+  "author": "Pavel Pertsev (port)",
+  "appearance": "dark",
+  "palette": {
+    "bg": "#1d2021",
+    "card": "#282828",
+    "card_2": "#232323",
+    "text_primary": "#ebdbb2",
+    "text_secondary": "#d5c4a1",
+    "text_body": "#ebdbb2",
+    "text_dim": "#928374",
+    "text_disabled": "#665c54",
+    "border": "#3c383680",
+    "border_hovered": "#928374",
+    "accent": "#fe8019",
+    "accent_dim": "#d65d0e",
+    "accent_tint": "#fe801926",
+    "shadow": { "color": "#00000066", "offset_x": 0.0, "offset_y": 10.0, "blur_radius": 22.0 },
+    "danger": "#fb4934",
+    "success": "#b8bb26"
+  }
+}

--- a/assets/themes/nord.json
+++ b/assets/themes/nord.json
@@ -1,0 +1,24 @@
+{
+  "schema": 1,
+  "name": "Nord",
+  "author": "Arctic Ice Studio (port)",
+  "appearance": "dark",
+  "palette": {
+    "bg": "#2e3440",
+    "card": "#3b4252",
+    "card_2": "#343a46",
+    "text_primary": "#eceff4",
+    "text_secondary": "#d8dee9",
+    "text_body": "#e5e9f0",
+    "text_dim": "#7b88a1",
+    "text_disabled": "#4c566a",
+    "border": "#4c566a80",
+    "border_hovered": "#7b88a1",
+    "accent": "#88c0d0",
+    "accent_dim": "#6fa8b8",
+    "accent_tint": "#88c0d026",
+    "shadow": { "color": "#0a0e1466", "offset_x": 0.0, "offset_y": 10.0, "blur_radius": 22.0 },
+    "danger": "#bf616a",
+    "success": "#a3be8c"
+  }
+}

--- a/assets/themes/solarized-light.json
+++ b/assets/themes/solarized-light.json
@@ -1,0 +1,24 @@
+{
+  "schema": 1,
+  "name": "Solarized Light",
+  "author": "Ethan Schoonover (port)",
+  "appearance": "light",
+  "palette": {
+    "bg": "#eee8d5",
+    "card": "#fdf6e3",
+    "card_2": "#f5eeda",
+    "text_primary": "#073642",
+    "text_secondary": "#586e75",
+    "text_body": "#657b83",
+    "text_dim": "#93a1a1",
+    "text_disabled": "#b5b09a",
+    "border": "#93a1a140",
+    "border_hovered": "#839496",
+    "accent": "#268bd2",
+    "accent_dim": "#1a6fad",
+    "accent_tint": "#268bd21f",
+    "shadow": { "color": "#00000026", "offset_x": 0.0, "offset_y": 8.0, "blur_radius": 18.0 },
+    "danger": "#dc322f",
+    "success": "#859900"
+  }
+}

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -1233,7 +1233,7 @@ impl Snapdash {
     pub fn style(&self, _theme: &iced::Theme) -> iced::theme::Style {
         iced::theme::Style {
             background_color: iced::Color::TRANSPARENT,
-            text_color: self.theme.palette().text_primary,
+            text_color: self.theme.palette.text_primary,
         }
     }
 }

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -2,7 +2,7 @@ use crate::ha::types::HaError;
 use crate::ha::{EntityState, HaConnectionConfig, HaEvent};
 use crate::logger::LogType;
 use crate::system_info::{SysinfoData, SystemInfo};
-use crate::theme::loader::reslove_theme;
+use crate::theme::loader::{available_themes, resolve_theme};
 use crate::ui::platform::window_settings;
 use crate::ui::settings::*;
 use crate::update;
@@ -17,7 +17,7 @@ use iced::{Element, Task};
 
 use crate::config::{Config, WidgetPosition};
 use crate::ha::token::{self, TokenPresence};
-use crate::theme::{ThemeDef, ThemeKind, builtin_themes, load_user_themes};
+use crate::theme::{DEFAULT_THEME, ThemeDef, ThemeKind};
 
 use super::window::{EntityWindowState, WindowKind, WindowState, find_window_id};
 
@@ -162,16 +162,12 @@ impl Default for Snapdash {
 
 impl Snapdash {
     pub fn new() -> Self {
-        let available_themes = {
-            let mut v = builtin_themes();
-            v.extend(load_user_themes());
-            v
-        };
+        let available_themes = available_themes();
 
-        let theme = available_themes
-            .first()
+        let theme = resolve_theme(DEFAULT_THEME, &available_themes)
+            .or_else(|| available_themes.first())
             .cloned()
-            .expect("at least builtin themes exist");
+            .expect("at least bultin theme exists");
 
         Self {
             config: Config::default(),
@@ -748,7 +744,7 @@ impl Snapdash {
                         // Resolve the persisted theme name against the catalog.
                         // Falls back to first builtin theme if name is unknown
                         if let Some(theme) =
-                            reslove_theme(&self.config.theme, &self.available_themes)
+                            resolve_theme(&self.config.theme, &self.available_themes)
                         {
                             self.theme = theme.clone();
                         } else {

--- a/src/app/snapdash.rs
+++ b/src/app/snapdash.rs
@@ -2,6 +2,7 @@ use crate::ha::types::HaError;
 use crate::ha::{EntityState, HaConnectionConfig, HaEvent};
 use crate::logger::LogType;
 use crate::system_info::{SysinfoData, SystemInfo};
+use crate::theme::loader::reslove_theme;
 use crate::ui::platform::window_settings;
 use crate::ui::settings::*;
 use crate::update;
@@ -16,7 +17,7 @@ use iced::{Element, Task};
 
 use crate::config::{Config, WidgetPosition};
 use crate::ha::token::{self, TokenPresence};
-use crate::theme::ThemeKind;
+use crate::theme::{ThemeDef, ThemeKind, builtin_themes, load_user_themes};
 
 use super::window::{EntityWindowState, WindowKind, WindowState, find_window_id};
 
@@ -37,7 +38,8 @@ pub enum FocusDirection {
 pub struct Snapdash {
     pub config: Config,
     pub token_presence: TokenPresence,
-    pub theme: ThemeKind,
+    pub theme: ThemeDef,
+    pub available_themes: Vec<ThemeDef>,
 
     pub ha: ha::HaState,
 
@@ -87,7 +89,7 @@ pub enum Message {
     },
     AnimationFrame(iced::time::Instant),
 
-    ThemeSelected(ThemeKind),
+    ThemeSelected(String),
     SaveConfig,
     ToggleWidget(String),
 
@@ -160,10 +162,22 @@ impl Default for Snapdash {
 
 impl Snapdash {
     pub fn new() -> Self {
+        let available_themes = {
+            let mut v = builtin_themes();
+            v.extend(load_user_themes());
+            v
+        };
+
+        let theme = available_themes
+            .first()
+            .cloned()
+            .expect("at least builtin themes exist");
+
         Self {
             config: Config::default(),
             token_presence: TokenPresence::Unchecked,
-            theme: ThemeKind::default(),
+            theme,
+            available_themes,
             ha: ha::HaState::default(),
             status: "-".into(),
             theme_options: vec![ThemeKind::MacLight, ThemeKind::MacDark],
@@ -728,9 +742,19 @@ impl Snapdash {
                     Ok(cfg) => {
                         let mut tasks: Vec<Task<Message>> = Vec::new();
 
-                        self.theme = cfg.theme;
                         self.config = cfg;
                         crate::autostart::validate_state(self.config.autostart);
+
+                        // Resolve the persisted theme name against the catalog.
+                        // Falls back to first builtin theme if name is unknown
+                        if let Some(theme) =
+                            reslove_theme(&self.config.theme, &self.available_themes)
+                        {
+                            self.theme = theme.clone();
+                        } else {
+                            tracing::warn!(name = %self.config.theme, "unknown theme, using defualt");
+                            self.theme = self.available_themes[0].clone();
+                        }
 
                         self.rebuild_selected_widgets();
                         self.set_status("Config loaded", LogType::Info);
@@ -955,11 +979,19 @@ impl Snapdash {
                 }
             }
 
-            Message::ThemeSelected(t) => {
-                self.theme = t;
-                self.config.theme = t;
-
-                self.save_config()
+            Message::ThemeSelected(name) => {
+                if let Some(theme) = self
+                    .available_themes
+                    .iter()
+                    .find(|t| t.name == name)
+                    .cloned()
+                {
+                    self.theme = theme;
+                    self.config.theme = name;
+                    self.save_config()
+                } else {
+                    Task::none()
+                }
             }
 
             Message::SaveConfig => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,13 +5,12 @@ use serde::{Deserialize, Serialize};
 
 use anyhow::{Context, Result};
 
-use crate::theme::ThemeKind;
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub ha_url: String,
     pub ha_token_present: bool,
-    pub theme: ThemeKind,
+    #[serde(default = "default_theme_name")]
+    pub theme: String,
     #[serde(default)]
     pub debug_overlay: bool,
     #[serde(default)]
@@ -44,7 +43,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             ha_url: "http://localhost:8123".into(),
-            theme: ThemeKind::default(),
+            theme: "Mac Dark".into(),
             ha_token_present: false,
             autostart: false,
             debug_overlay: false,
@@ -111,4 +110,8 @@ impl Config {
 
         Ok(())
     }
+}
+
+fn default_theme_name() -> String {
+    "Mac Dark".to_string()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 
 use anyhow::{Context, Result};
 
+use crate::theme::DEFAULT_THEME;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub ha_url: String,
@@ -113,5 +115,5 @@ impl Config {
 }
 
 fn default_theme_name() -> String {
-    "Mac Dark".to_string()
+    DEFAULT_THEME.to_string()
 }

--- a/src/theme/core.rs
+++ b/src/theme/core.rs
@@ -1,3 +1,4 @@
+use crate::theme::{hex_color, shadow};
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -18,28 +19,43 @@ impl fmt::Display for ThemeKind {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct Palette {
+    #[serde(with = "hex_color")]
     pub bg: iced::Color,
+    #[serde(with = "hex_color")]
     pub card: iced::Color,
+    #[serde(with = "hex_color")]
     pub card_2: iced::Color,
-
-    pub text_primary: iced::Color,   // main headings
+    #[serde(with = "hex_color")]
+    pub text_primary: iced::Color, // main headings
+    #[serde(with = "hex_color")]
     pub text_secondary: iced::Color, // subhedings, labels
-    pub text_body: iced::Color,      // normal text
-    pub text_dim: iced::Color,       // placeholder, hint
+    #[serde(with = "hex_color")]
+    pub text_body: iced::Color, // normal text
+    #[serde(with = "hex_color")]
+    pub text_dim: iced::Color, // placeholder, hint
+    #[serde(with = "hex_color")]
     pub text_disabled: iced::Color,
 
+    #[serde(with = "hex_color")]
     pub border: iced::Color,
+    #[serde(with = "hex_color")]
     pub border_hovered: iced::Color,
 
+    #[serde(with = "hex_color")]
     pub accent: iced::Color,
+    #[serde(with = "hex_color")]
     pub accent_dim: iced::Color,
+    #[serde(with = "hex_color")]
     pub accent_tint: iced::Color,
 
+    #[serde(with = "shadow")]
     pub shadow: iced::Shadow,
 
+    #[serde(with = "hex_color")]
     pub danger: iced::Color,
+    #[serde(with = "hex_color")]
     pub success: iced::Color,
 }
 
@@ -120,4 +136,48 @@ pub mod text_size {
     pub const XSMALL: f32 = 10.0;
     pub const LARGE: f32 = 15.0;
     pub const XLARGE: f32 = 22.0;
+}
+
+//
+//   TESTS
+//
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn palette_roundtrips_through_json() {
+        let original = ThemeKind::MacDark.palette();
+        let json = serde_json::to_string_pretty(&original).expect("serialize");
+        let restored: Palette = serde_json::from_str(&json).expect("deserialize");
+
+        // Compare a few key fields (Palette isn't PartialEq — compare components)
+        assert_eq!(original.accent.into_rgba8(), restored.accent.into_rgba8());
+        assert_eq!(original.bg.into_rgba8(), restored.bg.into_rgba8());
+        assert_eq!(original.shadow.blur_radius, restored.shadow.blur_radius);
+    }
+
+    #[test]
+    fn parses_opaque_and_alpha_hex() {
+        let json = r##"{
+            "bg": "#1e1e2e",
+            "card": "#282a36",
+            "card_2": "#21222c",
+            "text_primary": "#f8f8f2",
+            "text_secondary": "#e0e0d0",
+            "text_body": "#cdd6f4",
+            "text_dim": "#6272a4",
+            "text_disabled": "#45475a",
+            "border": "#44475a80",
+            "border_hovered": "#44475a",
+            "accent": "#bd93f9",
+            "accent_dim": "#a679e0",
+            "accent_tint": "#bd93f924",
+            "shadow": { "color": "#00000040", "offset_x": 0.0, "offset_y": 10.0, "blur_radius": 20.0 },
+            "danger": "#ff5555",
+            "success": "#50fa7b"
+        }"##;
+        let p: Palette = serde_json::from_str(json).expect("parse");
+        assert_eq!(p.accent.into_rgba8(), [189, 147, 249, 255]);
+    }
 }

--- a/src/theme/def.rs
+++ b/src/theme/def.rs
@@ -1,0 +1,152 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::core::Palette;
+
+/// Lightness hint for matching the OS dark/light mode and grouping in
+/// the picker. Not derived from the palette — declared by the theme.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Appearance {
+    Light,
+    #[default]
+    Dark,
+}
+
+/// Where a theme came from — drives whether it can be deleted/edited
+/// and how it's labeled in the picker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThemeSource {
+    Builtin,
+    UserFile(PathBuf),
+}
+
+/// A complete theme: identity metadata + the color palette. This is
+/// the unit the loader produces and the picker lists. The on-disk JSON
+/// shape matches the #[serde] fields below; `source` is set by the
+/// loader, not stored in the file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThemeDef {
+    /// Schema version for forward-compat migrations. Bump when the
+    /// palette gains required fields.
+    #[serde(default = "default_schema")]
+    pub schema: u32,
+
+    pub name: String,
+
+    #[serde(default)]
+    pub author: Option<String>,
+
+    #[serde(default)]
+    pub appearance: Appearance,
+
+    pub palette: Palette,
+
+    /// Not part of the JSON — filled in by the loader.
+    #[serde(skip, default = "default_source")]
+    pub source: ThemeSource,
+}
+
+fn default_schema() -> u32 {
+    1
+}
+
+fn default_source() -> ThemeSource {
+    ThemeSource::Builtin
+}
+
+impl ThemeDef {
+    /// Display label for the picker — "Dracula" or "Dracula — by X".
+    pub fn label(&self) -> String {
+        match &self.author {
+            Some(author) => format!("{} — by {author}", self.name),
+            None => self.name.clone(),
+        }
+    }
+}
+
+//
+// TESTS
+//
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn palette_json() -> &'static str {
+        r##"{
+               "bg": "#1e1e2e",
+               "card": "#282a36",
+               "card_2": "#21222c",
+               "text_primary": "#f8f8f2",
+               "text_secondary": "#e0e0d0",
+               "text_body": "#cdd6f4",
+               "text_dim": "#6272a4",
+               "text_disabled": "#45475a",
+               "border": "#44475a80",
+               "border_hovered": "#44475a",
+               "accent": "#bd93f9",
+               "accent_dim": "#a679e0",
+               "accent_tint": "#bd93f924",
+               "shadow": { "color": "#00000040", "offset_x": 0.0, "offset_y": 10.0, "blur_radius": 20.0 },
+               "danger": "#ff5555",
+               "success": "#50fa7b"
+           }"##
+    }
+    #[test]
+    fn parses_full_theme_json() {
+        let json = format!(
+            r##"{{
+                   "schema": 1,
+                   "name": "Dracula",
+                   "author": "Zeno Rocha",
+                   "appearance": "dark",
+                   "palette": {palette}
+               }}"##,
+            palette = palette_json(),
+        );
+
+        let theme: ThemeDef = serde_json::from_str(&json).expect("parse");
+        assert_eq!(theme.name, "Dracula");
+        assert_eq!(theme.schema, 1);
+        assert_eq!(theme.appearance, Appearance::Dark);
+        assert_eq!(theme.label(), "Dracula — by Zeno Rocha");
+        assert_eq!(theme.palette.accent.into_rgba8(), [189, 147, 249, 255]);
+        // source isn't in the JSON — defaults to Builtin
+        assert_eq!(theme.source, ThemeSource::Builtin);
+    }
+
+    #[test]
+    fn author_optional() {
+        let json = format!(
+            r##"{{
+                   "name": "Minimal",
+                   "palette": {palette}
+               }}"##,
+            palette = palette_json(),
+        );
+
+        let theme: ThemeDef = serde_json::from_str(&json).expect("parse");
+        assert_eq!(theme.name, "Minimal");
+        // author missing → None → label is just the name
+        assert_eq!(theme.author, None);
+        assert_eq!(theme.label(), "Minimal");
+        // schema missing → default 1
+        assert_eq!(theme.schema, 1);
+        // appearance missing → Default (Dark)
+        assert_eq!(theme.appearance, Appearance::Dark);
+    }
+
+    #[test]
+    fn rejects_malformed_palette() {
+        // Missing required field (no "success") → parse error.
+        let json = format!(
+            r##"{{
+                   "name": "Broken",
+                   "palette": {{ "bg": "#000000" }}
+               }}"##,
+        );
+        assert!(serde_json::from_str::<ThemeDef>(&json).is_err());
+    }
+}

--- a/src/theme/def.rs
+++ b/src/theme/def.rs
@@ -158,12 +158,11 @@ mod tests {
     #[test]
     fn rejects_malformed_palette() {
         // Missing required field (no "success") → parse error.
-        let json = format!(
-            r##"{{
+        let json = r##"{{
                    "name": "Broken",
                    "palette": {{ "bg": "#000000" }}
-               }}"##,
-        );
-        assert!(serde_json::from_str::<ThemeDef>(&json).is_err());
+               }}"##;
+
+        assert!(serde_json::from_str::<ThemeDef>(json).is_err());
     }
 }

--- a/src/theme/def.rs
+++ b/src/theme/def.rs
@@ -66,6 +66,23 @@ impl ThemeDef {
     }
 }
 
+impl std::fmt::Display for ThemeDef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.label())
+    }
+}
+
+// Identity = name. Two themes with the same name are "the same" for
+// picker selection; we deliberately don't compare palettes (would
+// require Palette: PartialEq and isn't the picker's notion of equality).
+impl PartialEq for ThemeDef {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+impl Eq for ThemeDef {}
+
 //
 // TESTS
 //

--- a/src/theme/hex_color.rs
+++ b/src/theme/hex_color.rs
@@ -1,0 +1,42 @@
+/// Serde (de)serialization for `iced::Color` as a hex string.
+/// Accepts `#rrggbb` (opaque) or `#rrggbbaa` (with alpha). Used via
+/// `#[serde(with = "hex_color")]` on Palette's color fields.use iced::Color;
+use iced::Color;
+use serde::{Deserialize, Deserializer, Serializer};
+
+pub fn serialize<S: Serializer>(color: &Color, s: S) -> Result<S::Ok, S::Error> {
+    let [r, g, b, a] = color.into_rgba8();
+    let hex = if a == 255 {
+        format!("#{r:02x}{g:02x}{b:02x}")
+    } else {
+        format!("#{r:02x}{g:02x}{b:02x}{a:02x}")
+    };
+    s.serialize_str(&hex)
+}
+
+pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Color, D::Error> {
+    let raw = String::deserialize(d)?;
+    parse_hex(&raw).map_err(serde::de::Error::custom)
+}
+
+fn parse_hex(raw: &str) -> Result<Color, String> {
+    let s = raw.trim().trim_start_matches('#');
+
+    let byte = |range: std::ops::Range<usize>| {
+        u8::from_str_radix(&s[range], 16).map_err(|e| format!("invalid hex '{raw}': {e}"))
+    };
+
+    match s.len() {
+        6 => Ok(Color::from_rgb8(byte(0..2)?, byte(2..4)?, byte(4..6)?)),
+        8 => Ok(Color::from_rgba8(
+            byte(0..2)?,
+            byte(2..4)?,
+            byte(4..6)?,
+            byte(6..8)? as f32 / 255.0,
+        )),
+        _ => Err(format!(
+            "hex color must be 6 or 8 digits, got '{raw}' ({} digits)",
+            s.len()
+        )),
+    }
+}

--- a/src/theme/loader.rs
+++ b/src/theme/loader.rs
@@ -1,0 +1,179 @@
+use std::path::PathBuf;
+
+use directories::ProjectDirs;
+
+use super::def::{Appearance, ThemeDef, ThemeSource};
+use crate::theme::ThemeKind;
+
+/// Directory where user themes live: `<config>/themes/`. Same
+/// ProjectDirs root as config.json, so users find both in one plac
+pub fn themes_dir() -> Option<PathBuf> {
+    ProjectDirs::from("dev", "snapdash", "Snapdash").map(|proj| proj.config_dir().join("themes"))
+}
+
+/// The two built-in themes, always available regardless of user files.
+/// Wrap the existing ThemeKind palettes as ThemeDef so the picker can
+/// treat builtin and user themes uniformly.
+pub fn builtin_themes() -> Vec<ThemeDef> {
+    vec![
+        ThemeDef {
+            schema: 1,
+            name: "Mac Light".to_string(),
+            author: None,
+            appearance: Appearance::Light,
+            palette: ThemeKind::MacLight.palette(),
+            source: ThemeSource::Builtin,
+        },
+        ThemeDef {
+            schema: 1,
+            name: "Mac Dark".to_string(),
+            author: None,
+            appearance: Appearance::Dark,
+            palette: ThemeKind::MacDark.palette(),
+            source: ThemeSource::Builtin,
+        },
+    ]
+}
+
+/// Loads all valid `.json` themes from the themes directory. Malformed
+/// files (bad JSON, missing fields, invalid hex) are logged and
+/// skipped — one broken theme never blocks the rest or the picker.
+/// Missing directory returns an empty list (not an error).
+pub fn load_user_themes() -> Vec<ThemeDef> {
+    match themes_dir() {
+        Some(dir) => load_themes_from(&dir),
+        None => {
+            tracing::warn!("could not resolve themes directory");
+            Vec::new()
+        }
+    }
+}
+
+pub fn load_themes_from(dir: &std::path::Path) -> Vec<ThemeDef> {
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // No themes dir yet — fine, user hasn't added any.
+            return Vec::new();
+        }
+        Err(e) => {
+            tracing::warn!(dir = %dir.display(), error = %e, "cannot read themes dir");
+            return Vec::new();
+        }
+    };
+
+    let mut themes = Vec::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+
+        match load_one(&path) {
+            Ok(theme) => {
+                tracing::info!(name = %theme.name, path = %path.display(), "loaded theme");
+                themes.push(theme);
+            }
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "skipping invalid theme");
+            }
+        }
+    }
+
+    themes
+}
+
+/// Parses a single theme file and tags it with its source path.
+fn load_one(path: &std::path::Path) -> anyhow::Result<ThemeDef> {
+    let bytes = std::fs::read(path)?;
+    let mut theme: ThemeDef = serde_json::from_slice(&bytes)?;
+    theme.source = ThemeSource::UserFile(path.to_path_buf());
+    Ok(theme)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_themes_always_present() {
+        let themes = builtin_themes();
+        assert_eq!(themes.len(), 2);
+        assert!(themes.iter().any(|t| t.name == "Mac Light"));
+        assert!(themes.iter().any(|t| t.name == "Mac Dark"));
+        assert!(themes.iter().all(|t| t.source == ThemeSource::Builtin));
+    }
+
+    #[test]
+    fn loads_valid_theme_and_tags_source() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("dracula.json");
+        std::fs::write(&path, valid_theme_json()).unwrap();
+
+        let themes = load_themes_from(dir.path());
+
+        assert_eq!(themes.len(), 1);
+        assert_eq!(themes[0].name, "Dracula");
+        // loader tags the file path as the source
+        assert_eq!(themes[0].source, ThemeSource::UserFile(path));
+    }
+
+    #[test]
+    fn skips_invalid_files_keeps_valid() {
+        // Use a temp dir with one valid + one broken theme.
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        std::fs::write(dir.path().join("good.json"), valid_theme_json()).unwrap();
+
+        std::fs::write(
+            dir.path().join("broken.json"),
+            r##"{ "name": "Broken", "palette": { "bg": "#000" } }"##, // missing fields
+        )
+        .unwrap();
+
+        std::fs::write(dir.path().join("notes.txt"), "ignore me").unwrap();
+
+        // load_dir is a testable variant that takes an explicit path
+        let themes = load_themes_from(dir.path());
+        assert_eq!(themes.len(), 1);
+        assert_eq!(themes[0].name, "Dracula");
+    }
+
+    #[test]
+    fn missing_dir_returns_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let nonexistent = dir.path().join("does_not_exist");
+
+        let themes = load_themes_from(&nonexistent);
+
+        assert!(themes.is_empty());
+    }
+
+    fn valid_theme_json() -> &'static str {
+        r##"{
+               "schema": 1,
+               "name": "Dracula",
+               "author": "Zeno Rocha",
+               "appearance": "dark",
+               "palette": {
+                   "bg": "#1e1e2e",
+                   "card": "#282a36",
+                   "card_2": "#21222c",
+                   "text_primary": "#f8f8f2",
+                   "text_secondary": "#e0e0d0",
+                   "text_body": "#cdd6f4",
+                   "text_dim": "#6272a4",
+                   "text_disabled": "#45475a",
+                   "border": "#44475a80",
+                   "border_hovered": "#44475a",
+                   "accent": "#bd93f9",
+                   "accent_dim": "#a679e0",
+                   "accent_tint": "#bd93f924",
+                   "shadow": { "color": "#00000040", "offset_x": 0.0, "offset_y": 10.0, "blur_radius": 20.0 },
+                   "danger": "#ff5555",
+                   "success": "#50fa7b"
+               }
+           }"##
+    }
+}

--- a/src/theme/loader.rs
+++ b/src/theme/loader.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
 use directories::ProjectDirs;
 
@@ -35,11 +35,36 @@ pub fn builtin_themes() -> Vec<ThemeDef> {
     ]
 }
 
+/// The full theme catalog: builtins first, then user themes, deduped
+/// by name. Builtins win over same-named user files. Does filesystem
+/// IO (scans the themes dir) — call once at startup.
+pub fn available_themes() -> Vec<ThemeDef> {
+    merge_unique(builtin_themes(), load_user_themes())
+}
+
+/// Merges two theme lists keeping the first occurrence of each name,
+/// so name-based lookup (resolve_theme) stays deterministic. Split out
+/// from available_themes() so the dedup rule is unit-testable without
+/// touching the filesystem.
+fn merge_unique(first: Vec<ThemeDef>, second: Vec<ThemeDef>) -> Vec<ThemeDef> {
+    let mut seen: HashSet<String> = first.iter().map(|t| t.name.clone()).collect();
+    let mut out = first;
+
+    for theme in second {
+        if seen.insert(theme.name.clone()) {
+            out.push(theme);
+        } else {
+            tracing::warn!(name = %theme.name, "duplicate theme name — skipping");
+        }
+    }
+    out
+}
+
 /// Resolves a stored theme name against the available catalog.
 /// Falls back through legacy ThemeKind enum names ("MacDark") for
 /// configs written before themes were named. Returns None if nothing
 /// matches — caller picks a default.
-pub fn reslove_theme<'a>(name: &str, available: &'a [ThemeDef]) -> Option<&'a ThemeDef> {
+pub fn resolve_theme<'a>(name: &str, available: &'a [ThemeDef]) -> Option<&'a ThemeDef> {
     if let Some(t) = available.iter().find(|t| t.name == name) {
         return Some(t);
     }

--- a/src/theme/loader.rs
+++ b/src/theme/loader.rs
@@ -68,7 +68,7 @@ pub fn load_user_themes() -> Vec<ThemeDef> {
 }
 
 pub fn load_themes_from(dir: &std::path::Path) -> Vec<ThemeDef> {
-    let entries = match std::fs::read_dir(&dir) {
+    let entries = match std::fs::read_dir(dir) {
         Ok(entries) => entries,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             // No themes dir yet — fine, user hasn't added any.

--- a/src/theme/loader.rs
+++ b/src/theme/loader.rs
@@ -35,6 +35,24 @@ pub fn builtin_themes() -> Vec<ThemeDef> {
     ]
 }
 
+/// Resolves a stored theme name against the available catalog.
+/// Falls back through legacy ThemeKind enum names ("MacDark") for
+/// configs written before themes were named. Returns None if nothing
+/// matches — caller picks a default.
+pub fn reslove_theme<'a>(name: &str, available: &'a [ThemeDef]) -> Option<&'a ThemeDef> {
+    if let Some(t) = available.iter().find(|t| t.name == name) {
+        return Some(t);
+    }
+    // Legacy migration: old config stores the ThemeKind enum variant.
+    let migrated = match name {
+        "MacDark" => "Mac Dark",
+        "MacLight" => "Mac Light",
+        _ => return None,
+    };
+
+    available.iter().find(|t| t.name == migrated)
+}
+
 /// Loads all valid `.json` themes from the themes directory. Malformed
 /// files (bad JSON, missing fields, invalid hex) are logged and
 /// skipped — one broken theme never blocks the rest or the picker.

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1,0 +1,5 @@
+pub mod hex_color;
+pub mod shadow;
+pub mod core;
+
+pub use core::{Palette, ThemeKind, metric, text_size};

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1,7 +1,9 @@
 pub mod core;
 pub mod def;
 pub mod hex_color;
+pub mod loader;
 pub mod shadow;
 
 pub use core::{Palette, ThemeKind, metric, text_size};
 pub use def::{Appearance, ThemeDef, ThemeSource};
+pub use loader::{builtin_themes, load_user_themes, themes_dir};

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1,5 +1,7 @@
+pub mod core;
+pub mod def;
 pub mod hex_color;
 pub mod shadow;
-pub mod core;
 
 pub use core::{Palette, ThemeKind, metric, text_size};
+pub use def::{Appearance, ThemeDef, ThemeSource};

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -7,3 +7,5 @@ pub mod shadow;
 pub use core::{Palette, ThemeKind, metric, text_size};
 pub use def::{Appearance, ThemeDef, ThemeSource};
 pub use loader::{builtin_themes, load_user_themes, themes_dir};
+
+pub const DEFAULT_THEME: &str = "Mac Dark";

--- a/src/theme/shadow.rs
+++ b/src/theme/shadow.rs
@@ -1,0 +1,32 @@
+/// Serde for `iced::Shadow` as a nested object:
+/// `{ "color": "#000000", "offset_x": 0.0, "offset_y": 10.0, "blur_radius": 20.0 }`.
+use iced::{Color, Shadow, Vector};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Serialize, Deserialize)]
+pub struct ShadowSpec {
+    #[serde(with = "super::hex_color")]
+    color: Color,
+    offset_x: f32,
+    offset_y: f32,
+    blur_radius: f32,
+}
+
+pub fn serialize<S: Serializer>(shadow: &Shadow, s: S) -> Result<S::Ok, S::Error> {
+    ShadowSpec {
+        color: shadow.color,
+        offset_x: shadow.offset.x,
+        offset_y: shadow.offset.y,
+        blur_radius: shadow.blur_radius,
+    }
+    .serialize(s)
+}
+
+pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Shadow, D::Error> {
+    let spec = ShadowSpec::deserialize(d)?;
+    Ok(Shadow {
+        color: spec.color,
+        offset: Vector::new(spec.offset_x, spec.offset_y),
+        blur_radius: spec.blur_radius,
+    })
+}

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -17,7 +17,7 @@ pub fn window_content<'a>(
         WindowKind::Settings => crate::ui::settings::view(app, id),
         WindowKind::Entity { .. } => crate::ui::entity_window::view(
             &win.entity,
-            app.theme.palette(),
+            app.theme.palette,
             app.ha.connected,
             app.update.is_available(),
             app.config.widget_settings,
@@ -43,7 +43,7 @@ pub fn with_gear_overlay<'a>(
         return inner;
     }
 
-    let p = app.theme.palette();
+    let p = app.theme.palette;
 
     let gear_button = iced::widget::button(Icon::Gear.text(p))
         .padding(8)

--- a/src/ui/components/button.rs
+++ b/src/ui/components/button.rs
@@ -335,7 +335,7 @@ pub fn icon_button<'a>(
 
     p: Palette,
 ) -> Element<'a, Message> {
-    let size = text_size.unwrap_or(crate::theme::text_size::SMALL);
+    let size = text_size.unwrap_or(text_size::SMALL);
     let mut i = icon.text(p).size(size);
     if let Some(c) = color {
         i = i.color(c);

--- a/src/ui/components/input.rs
+++ b/src/ui/components/input.rs
@@ -3,7 +3,7 @@ use iced::widget::{pick_list, text_input};
 use iced::{Background, Border};
 
 use crate::app::Message;
-use crate::theme::{Palette, ThemeKind, metric, text_size};
+use crate::theme::{Palette, ThemeDef, ThemeKind, metric, text_size};
 
 /// text_input wrapper to sytle as mac input
 pub fn mac_input<'a>(
@@ -102,11 +102,16 @@ where
 
 /// wrapper aroud pick_list
 pub fn themepicker(
-    options: Vec<ThemeKind>,
-    selected: ThemeKind,
+    options: Vec<ThemeDef>,
+    selected: ThemeDef,
     p: Palette,
-) -> pick_list::PickList<'static, ThemeKind, Vec<ThemeKind>, ThemeKind, Message> {
-    picker(options, selected, Message::ThemeSelected, p)
+) -> pick_list::PickList<'static, ThemeDef, Vec<ThemeDef>, ThemeDef, Message> {
+    picker(
+        options,
+        selected,
+        |theme: ThemeDef| Message::ThemeSelected(theme.name),
+        p,
+    )
 }
 
 pub fn toggler<'a, F, M>(is_checked: bool, on_toggle: F, p: Palette) -> iced::widget::Toggler<'a, M>

--- a/src/ui/components/input.rs
+++ b/src/ui/components/input.rs
@@ -3,7 +3,7 @@ use iced::widget::{pick_list, text_input};
 use iced::{Background, Border};
 
 use crate::app::Message;
-use crate::theme::{Palette, ThemeDef, ThemeKind, metric, text_size};
+use crate::theme::{Palette, ThemeDef, metric, text_size};
 
 /// text_input wrapper to sytle as mac input
 pub fn mac_input<'a>(

--- a/src/ui/release_notes.rs
+++ b/src/ui/release_notes.rs
@@ -7,7 +7,7 @@ use crate::ui::components;
 use crate::ui::icon::Icon;
 
 pub fn view<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
-    let p = snap.theme.palette();
+    let p = snap.theme.palette;
 
     let title_text = match &snap.update.latest_release {
         Some(r) => format!("Update to {}", r.tag_name),
@@ -49,9 +49,9 @@ pub fn view<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
     )
     .into();
 
-    let md_theme: iced::Theme = match snap.theme {
-        crate::theme::ThemeKind::MacLight => iced::Theme::Light,
-        crate::theme::ThemeKind::MacDark => iced::Theme::Dark,
+    let md_theme: iced::Theme = match snap.theme.appearance {
+        crate::theme::Appearance::Light => iced::Theme::Light,
+        crate::theme::Appearance::Dark => iced::Theme::Dark,
     };
 
     let base_md_style = markdown::Style::from_palette(md_theme.palette());

--- a/src/ui/settings/chrome.rs
+++ b/src/ui/settings/chrome.rs
@@ -13,7 +13,7 @@ use crate::ui::icon::Icon;
 use crate::ui::update_view;
 
 pub fn title_bar<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message> {
-    let p = snap.theme.palette();
+    let p = snap.theme.palette;
 
     let update_badge: Element<Message> = if snap.update.is_available() {
         mouse_area(components::badge_with_icon(
@@ -48,7 +48,7 @@ pub fn title_bar<'a>(snap: &'a Snapdash, id: window::Id) -> Element<'a, Message>
 }
 
 pub fn footer<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
-    let p = snap.theme.palette();
+    let p = snap.theme.palette;
 
     let status: Element<Message> = if !snap.status.is_empty() {
         components::dimmed(snap.status.clone(), p).into()

--- a/src/ui/settings/mod.rs
+++ b/src/ui/settings/mod.rs
@@ -47,7 +47,7 @@ mod pages;
 mod sidebar;
 
 pub fn view(snap: &Snapdash, id: iced::window::Id) -> Element<'_, Message> {
-    let p = snap.theme.palette();
+    let p = snap.theme.palette;
 
     let content: Element<Message> = match snap.settings_page {
         SettingsPage::General => pages::general::view(snap),

--- a/src/ui/settings/pages/advanced.rs
+++ b/src/ui/settings/pages/advanced.rs
@@ -9,7 +9,7 @@ use crate::ui::icon;
 use crate::{helpers, logger};
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
-    let p = snap.theme.palette();
+    let p = snap.theme.palette;
 
     let size = logger::get_log_size().unwrap_or(0);
     let log_size_helper = format!(

--- a/src/ui/settings/pages/appearance.rs
+++ b/src/ui/settings/pages/appearance.rs
@@ -1,11 +1,12 @@
 use iced::Element;
 
 use crate::app::{Message, Snapdash};
+use crate::theme::ThemeDef;
 use crate::ui::components::settings_components;
 use crate::widget_size::WidgetSize;
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
-    let p = snap.theme.palette();
+    let p = snap.theme.palette;
 
     settings_components::page_with_sections(
         "Appearance",
@@ -15,9 +16,9 @@ pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
                 [settings_components::item_with_picker(
                     "Theme",
                     None,
-                    snap.theme_options.clone(),
-                    snap.theme,
-                    Message::ThemeSelected,
+                    snap.available_themes.clone(),
+                    snap.theme.clone(),
+                    |theme: ThemeDef| Message::ThemeSelected(theme.name),
                     p,
                 )],
                 p,

--- a/src/ui/settings/pages/connection.rs
+++ b/src/ui/settings/pages/connection.rs
@@ -7,7 +7,7 @@ use crate::ui::components::{self, ButtonVisual, settings_components};
 use crate::ui::icon::Icon;
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
-    let p = snap.theme.palette();
+    let p = snap.theme.palette;
 
     let token_item = match &snap.token_presence {
         TokenPresence::Missing => settings_components::item_with_input(

--- a/src/ui/settings/pages/general.rs
+++ b/src/ui/settings/pages/general.rs
@@ -9,7 +9,7 @@ use crate::ui::icon::Icon;
 use crate::update;
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
-    let p = snap.theme.palette();
+    let p = snap.theme.palette;
 
     // Hero
     let hero = column![

--- a/src/ui/settings/pages/sensors.rs
+++ b/src/ui/settings/pages/sensors.rs
@@ -6,7 +6,7 @@ use crate::theme::metric;
 use crate::ui::components::{self, active_sensor_section, sensors_section};
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
-    let p = snap.theme.palette();
+    let p = snap.theme.palette;
 
     let search: Element<Message> =
         components::mac_input("Search entities ...", &snap.entity_search_query, p)

--- a/src/ui/settings/pages/updates.rs
+++ b/src/ui/settings/pages/updates.rs
@@ -8,7 +8,7 @@ use crate::ui::update_view;
 use crate::update::{self, InstallProgress, UpdateState};
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
-    let p = snap.theme.palette();
+    let p = snap.theme.palette;
 
     let latest = match &snap.update.latest_release {
         Some(release) => release.tag_name.to_string(),

--- a/src/ui/settings/sidebar.rs
+++ b/src/ui/settings/sidebar.rs
@@ -8,7 +8,7 @@ use crate::theme::{Palette, metric, text_size};
 use super::SettingsPage;
 
 pub fn view<'a>(snap: &'a Snapdash) -> Element<'a, Message> {
-    let p = snap.theme.palette();
+    let p = snap.theme.palette;
 
     let mut nav = column![].spacing(2);
     for &page in SettingsPage::ALL {


### PR DESCRIPTION
## Summary

Adds user-supplied JSON themes on top of the built-in Mac Light / Mac
Dark. Drop a `*.json` into the themes folder and it shows up in
**Settings → Appearance → Theme** — switching applies instantly, the
choice persists. Covers both user-authored and downloaded themes (the
app doesn't care where the file came from).

## How it works

- **Palette serde** — `iced::Color` / `iced::Shadow` lack serde, handled
  via `#[serde(with)]` helpers: `hex_color` (`#rrggbb` / `#rrggbbaa`)
  and `shadow` (nested `{ color, offset_x, offset_y, blur_radius }`).
- **ThemeDef** wraps a Palette with metadata: `schema` (forward-compat),
  `name`, optional `author`, `appearance` hint (light/dark), and a
  loader-set `source` (Builtin / UserFile, skipped in JSON).
- **Loader** — `builtin_themes()` wraps the two hardcoded palettes;
  `load_themes_from(dir)` scans `*.json` and **skips malformed files**
  (bad JSON, missing fields, invalid hex) with a tracing warning. One
  broken theme never blocks the rest or crashes the picker. Missing
  dir = empty, not an error.
- **State + config** — `Config.theme` is a String name now; legacy
  `ThemeKind` enum values ("MacDark") migrate via `resolve_theme`.
  `Snapdash.available_themes` (builtin + user) + active `ThemeDef`.
- **Picker** lists everything by label ("Name — by Author"); ThemeDef
  gets Display/PartialEq/Hash (identity by name) for `pick_list`.

## Themes shipped

`assets/themes/`: Dracula, Nord, Catppuccin Mocha, Gruvbox Dark,
Solarized Light (the last exercises the `appearance: "light"` path).

## Docs

README gains a Custom themes section: per-platform folder, full JSON
schema (top-level + all 16 palette fields), hex format, skip-on-error.
Roadmap corrected (themes/autostart/auto-update checked, local history
unchecked — it isn't done yet).