### PR TITLE
Release v0.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "snapdash"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "auto-launch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snapdash"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2024"
 authors = ["Lukáš Svoboda <opensource@schizza.cz>"]
 license = "Apache-2.0"

--- a/src/ui/entity_window.rs
+++ b/src/ui/entity_window.rs
@@ -29,17 +29,22 @@ fn status_line(p: Palette, connected: bool) -> Element<'static, Message> {
     row![dot].spacing(8).align_y(Alignment::End).into()
 }
 
-fn pulse_border(p: Palette, pulse: f32) -> iced::Color {
+/// Ring pulse color for the card border.
+///
+/// Normal/Low widgets rest faint and flash to accent on a state update
+/// (dimmed → accent → dimmed). High-priority widgets rest on a steady
+/// accent ring and *invert* the pulse — they dip to dimmed and return
+/// (accent → dimmed → accent) — so the update feedback survives the
+/// always-on emphasis ring.
+fn pulse_border(p: Palette, pulse: f32, priority: Priority) -> iced::Color {
     let t = pulse.clamp(0.0, 1.0);
 
-    let a = 0.10 + 0.55 * t;
+    let a = match priority {
+        Priority::Low | Priority::Normal => 0.15 + 0.55 * t,
+        Priority::High => 0.65 - 0.50 * t,
+    };
 
-    iced::Color {
-        r: p.accent.r,
-        g: p.accent.g,
-        b: p.accent.b,
-        a,
-    }
+    iced::Color { a, ..p.accent }
 }
 
 pub fn view(
@@ -127,13 +132,7 @@ pub fn view(
     let disconnected_text =
         components::error_message("You are disconected from Home Assistant!", p);
 
-    let ring = match priority {
-        Priority::High => iced::Color {
-            a: 0.55,
-            ..p.accent
-        },
-        _ => pulse_border(p, state.pulse.value()),
-    };
+    let ring = pulse_border(p, state.pulse.value(), priority);
 
     let inner = column![
         title_text,


### PR DESCRIPTION
fix(widget): invert ring pulse for high-priority widgets

High-priority widgets locked the ring to a steady accent, swallowing the
on-update pulse feedback. Drive the ring from a single priority-aware
function: Normal/Low keep the faint→accent flash, High now inverts it —
resting on the accent ring and dipping to dimmed (0.15, above the border
width threshold so it dims rather than blinking off) and back on update.